### PR TITLE
fix: trigger release.yml on push to release, not pull_request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
 name: Release
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - release
+
 jobs:
   deployment:
     name: Deploy
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,7 +18,6 @@ jobs:
 
   semantic-release:
     name: Semantic Release
-    if: github.event.pull_request.merged == true
     needs: deployment
     permissions:
       contents: write


### PR DESCRIPTION
## 1. Target

Hotfix to PR #46. No issue number — direct follow-up to a bug discovered after #46 merged.

## 2. Specification / Test Plan

The release pipeline shipped in #46 triggers \`release.yml\` on \`pull_request: closed\` to \`release\`. semantic-release explicitly skips that trigger:

> This run was triggered by a pull request and therefore a new version won't be published.

(Observed in run [24980145084](https://github.com/spencer-osbrjp/bungkus-cli/actions/runs/24980145084).)

This PR switches the trigger to \`push: branches: [release]\` and drops the now-redundant \`if: github.event.pull_request.merged == true\` guards. Functionally equivalent under branch protection (force-push blocked, PRs required → \`push\` only happens via merged PR), but is the trigger semantic-release expects.

**Verification plan:**
1. Merge this PR to \`main\`.
2. \`promote.yml\` opens the next \`main → release\` PR.
3. Merge that promotion PR.
4. \`release.yml\` should run on the \`push\` event and \`semantic-release\` should produce a SemVer tag (likely \`v1.0.0\` since prior \`2026.04.week4.release1\` won't match SemVer pattern).
5. \`publish.yml\` then attaches the four binaries + \`checksums.txt\`.

**Note on the orphan tag:** \`2026.04.week4.release1\` from the first run will remain in GitHub Releases as a one-off relic. semantic-release ignores it, so the next release starts from scratch as if no prior release existed. Delete it manually if you want it gone.

## 3. Additional Instructions / Notes for Shipping (optional)

None.

## 4. Check before Review Request

* [ ] Self Review : I reviewed changes by myself and approved them.
* [ ] Evidence : I attached evidences to prove the changes.

## 5. Evidence

(Attach here before request review)