### PR TITLE
feat: embed version in binary, document binary install in README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -o bungkus-cli-${{ matrix.goos }}-${{ matrix.goarch }} .
+          go build -ldflags "-X main.Version=${{ needs.semantic-release.outputs.new_release_git_tag }}" -o bungkus-cli-${{ matrix.goos }}-${{ matrix.goarch }} .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -29,6 +29,32 @@ Add-ons are integration-aware: forms, queries, and state libraries are filtered 
 
 ### Install
 
+Download the latest release binary for your platform (`darwin`/`linux` × `arm64`/`amd64`) and verify its SHA256:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/spencer-osbrjp/bungkus-cli/main/install.sh | bash
+```
+
+Defaults to `/usr/local/bin/bungkus-cli` (uses `sudo` if needed). Override with `BUNGKUS_INSTALL_DIR`:
+
+```bash
+BUNGKUS_INSTALL_DIR=$HOME/.local/bin curl -fsSL https://raw.githubusercontent.com/spencer-osbrjp/bungkus-cli/main/install.sh | bash
+```
+
+Update to the latest release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/spencer-osbrjp/bungkus-cli/main/update.sh | bash
+```
+
+Confirm:
+
+```bash
+bungkus-cli --version
+```
+
+If you have Go installed and prefer to build from source:
+
 ```bash
 go install github.com/spencer-osbrjp/bungkus-cli@latest
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,10 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+func SetVersion(v string) {
+	rootCmd.Version = v
+}
+
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -18,5 +18,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to load registry: %v\n", err)
 		os.Exit(1)
 	}
+	cmd.SetVersion(Version)
 	cmd.Execute()
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,5 @@
+package main
+
+// Version is set at build time via -ldflags "-X main.Version=...".
+// Defaults to "dev" for local builds.
+var Version = "dev"


### PR DESCRIPTION
Adds version.go in the main package with Version defaulting to "dev", exposed through cmd.SetVersion so cobra wires --version automatically. release.yml's matrix build now injects the new tag via -ldflags "-X main.Version=$tag", so released binaries report their actual SemVer.

Verified locally:
  go build .                                  -> --version: dev
  go build -ldflags "-X main.Version=vX" .    -> --version: vX

README: replace go-install-only "Getting Started" section with the binary install path (install.sh + update.sh) as the primary install, keeping go install as a fallback for source builds.