### PR TITLE
feat: add Memory section, .wiki knowledge base to scaffold

### DIFF
--- a/config/templates/shared/.wiki/README.md
+++ b/config/templates/shared/.wiki/README.md
@@ -1,0 +1,8 @@
+# Project Wiki (Knowledge Base)
+
+This directory is the project's knowledge base. Store all project knowledge here —
+specs, design docs, meeting notes, reference PDFs, images, diagrams, and any other
+material an agent or developer might need for context.
+
+Agents should read relevant files here before starting a task and add new knowledge
+as the project evolves.

--- a/config/templates/shared/AGENTS.md.tmpl
+++ b/config/templates/shared/AGENTS.md.tmpl
@@ -31,6 +31,10 @@ Use the information below as the standard workflow and criteria check-point:
 - Always ensure no errors show after code changes (can run `build`)
 - Always ensure the test pass if test cases are provided (can run `test`)
 
+## Memory
+
+**Always keep memory up to date as you work.** Record decisions, conventions, gotchas, and project state in `.claude/memories/memory-*.md` (one topic per file, e.g. `.claude/memories/memory-auth.md`). Read existing memory files at the start of a task and update or add to them as you go — don't wait until the end.
+
 ## Secrets and sensitive data
 - Never print secrets (tokens, private keys, credentials) to terminal output.
 - Do not request users paste secrets.

--- a/config/templates/shared/AGENTS.md.tmpl
+++ b/config/templates/shared/AGENTS.md.tmpl
@@ -35,6 +35,10 @@ Use the information below as the standard workflow and criteria check-point:
 
 **Always keep memory up to date as you work.** Record decisions, conventions, gotchas, and project state in `.claude/memories/memory-*.md` (one topic per file, e.g. `.claude/memories/memory-auth.md`). Read existing memory files at the start of a task and update or add to them as you go — don't wait until the end.
 
+## Wiki (Knowledge Base)
+
+The `.wiki/` directory is the project's knowledge base and contains all project knowledge — specs, design docs, notes, reference PDFs, images, diagrams, and any other supporting material. Treat it as the source of truth for context: read relevant files there before starting a task, and add new knowledge to it as the project evolves.
+
 ## Secrets and sensitive data
 - Never print secrets (tokens, private keys, credentials) to terminal output.
 - Do not request users paste secrets.

--- a/config/templates/shared/README.md.tmpl
+++ b/config/templates/shared/README.md.tmpl
@@ -26,6 +26,10 @@ https://docs.npmjs.com/cli/v10/configuring-npm/install
 | {{ .Tech }} | {{ .Name }} | {{ .Version }} |
 {{- end }}
 
+## Wiki (Knowledge Base)
+
+The `.wiki/` directory is the project's knowledge base. Store all project knowledge there — specs, design docs, notes, reference PDFs, images, and diagrams. It acts as the source of truth for project context.
+
 {{ if eq .Audit "lhci" }}
 ## Lighthouse CI Notes
 


### PR DESCRIPTION
Closes #75

- Add **Memory** workflow section to scaffolded `AGENTS.md`
- Scaffold a `.wiki/` knowledge base directory (specs, docs, PDFs, images)
- Document the wiki in scaffolded `AGENTS.md` and `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)