### PR TITLE
feat: announce published releases in Slack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,3 +113,35 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ needs.semantic-release.outputs.new_release_git_tag }}" assets/* --repo "${{ github.repository }}"
+
+  announce:
+    name: Announce release on Slack
+    needs: [semantic-release, upload-assets]
+    if: needs.semantic-release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release announcement
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          NAME: ${{ github.event.repository.name }}
+          TAG: ${{ needs.semantic-release.outputs.new_release_git_tag }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set — skipping Slack announcement"
+            exit 0
+          fi
+
+          title=$(gh release view "$TAG" --repo "$REPO" --json name --jq '.name // ""')
+          body=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body // ""')
+          url=$(gh release view "$TAG" --repo "$REPO" --json url --jq '.url')
+
+          header="*${NAME}@${TAG}*"
+          if [ -n "$title" ] && [ "$title" != "$TAG" ]; then
+            header="${header} — ${title}"
+          fi
+          text="${header}"$'\n\n'"${body}"$'\n\n'"<${url}|View release>"
+
+          jq -n --arg t "$text" '{text: $t}' \
+            | curl -sSf -X POST -H 'Content-type: application/json' --data @- "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Closes #82.

## Summary
Adds an `announce` job to the release workflow that posts to a Slack channel when a new release is published.

- Runs after `upload-assets`, gated on `new_release_published == 'true'`.
- Pulls the release name + notes via `gh`, posts to a Slack **Incoming Webhook**.
- Message: `bungkus-cli@<version> — <title>` + changelog + link to the GitHub release.
- **Skips gracefully** if `SLACK_WEBHOOK_URL` is unset — never blocks a release.
- Payload built with `jq --arg`, so changelog quotes/newlines can't break the JSON.

## Setup required
Add a repo secret **`SLACK_WEBHOOK_URL`** (Slack Incoming Webhook bound to the target channel). Until it's set, the job logs "skipping" and does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
