### PR TITLE
fix: silence semantic-release comment/email spam

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,14 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false,
+        "failTitle": false,
+        "releasedLabels": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Disables `successComment`, `failComment`, `failTitle`, and `releasedLabels` on `@semantic-release/github`. These post a comment on every PR/issue referenced in a release (proportional to commit count) and open failure issues — the source of the Gmail spam, made worse by canary running on every push to main. Merge to stop it; then promote main→release (merge commit) so the release branch gets it too. 🤖 Generated with [Claude Code](https://claude.com/claude-code)