### PR TITLE
fix(ci): build/scan on latest 1.25 Go patch to clear stdlib govulncheck failures

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,11 @@ jobs:
             })
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          # Use the latest 1.25 patch so the toolchain's standard library carries
+          # stdlib security fixes. govulncheck flags stdlib advisories against the
+          # exact toolchain version, and go.mod's `go 1.25.0` would pin an
+          # unpatched stdlib (crypto/tls, net/textproto, crypto/x509 advisories).
+          go-version: "1.25.x"
       - name: Build and run tests
         run: |
           go build -o /dev/null .


### PR DESCRIPTION
## Problem
The `Run Tests` → **Vulnerability scan** step fails (e.g. on PR #90) with Go **standard-library** advisories:
- `GO-2026-5856` crypto/tls — *fixed in go1.25.12*
- `GO-2026-5039` net/textproto — *fixed in go1.25.11*
- `GO-2026-5037` crypto/x509 — *fixed in go1.25.11*

`actions/setup-go` installs exactly `go 1.25.0` (from `go.mod`'s `go` directive), and `govulncheck` reports stdlib vulnerabilities against the exact toolchain version — so an unpatched stdlib fails the scan even though our own dependencies are clean.

## Fix
Pin the CI toolchain to `go-version: "1.25.x"` (latest 1.25 patch) instead of `go-version-file: go.mod`, so the standard library carries upstream security fixes. Resilient to future stdlib patch advisories within 1.25 without a `go.mod` bump each time.

Verified locally with `GOTOOLCHAIN=go1.25.12`: `govulncheck ./...` → **No vulnerabilities found**; `go build` + `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)