### PR TITLE
ci(templates): stop scaffolding a Lighthouse workflow that burns minutes

### DIFF
--- a/config/templates/audit/lhci/.github/workflows/lhci.yml.tmpl
+++ b/config/templates/audit/lhci/.github/workflows/lhci.yml.tmpl
@@ -1,9 +1,25 @@
 name: Lighthouse CI
+
+# Pull requests only. GitHub runs this against the merge result rather than the branch
+# head, so a post-merge run on the default branch would re-audit a tree that has already
+# passed — a full duplicate audit for every change.
+#
+# Run it by hand on any ref from Actions -> Run workflow, or:
+#   gh workflow run "Lighthouse CI" --ref main
 on:
-  push:
-    branches: [main, dev, staging, test]
   pull_request:
-    branches: [main, dev, staging, test]
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/**'
+  workflow_dispatch:
+
+# Only the newest tree is worth measuring. Without this, several pushes in quick
+# succession each run a full audit through to completion.
+concurrency:
+  group: lhci-{{ "${{ github.ref }}" }}
+  cancel-in-progress: true
 
 jobs:
   lighthouseci:

--- a/config/templates/audit/lhci/lighthouserc.json.tmpl
+++ b/config/templates/audit/lhci/lighthouserc.json.tmpl
@@ -3,14 +3,15 @@
     "collect": {
       "startServerCommand": "{{ .PM }} run preview --port 3000",
       "url": ["http://localhost:3000"],
-      "numberOfRuns": 3
+      "numberOfRuns": 1
     },
     "upload": {
       "target": "temporary-public-storage"
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.5 }]
+        "categories:performance": ["error", { "minScore": 0.5 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }]
       }
     }
   }


### PR DESCRIPTION
Every project generated with `--audit lhci` inherited a workflow that audited twice per change, had no concurrency guard, and repeated the audit three times per run.

## Measured on a real repo built from this template

Lighthouse was **65 of ~82 Actions minutes** across 100 runs. Per-step timings put **62 of 89 seconds inside `lhci autorun` itself** — install and build were never the problem.

## Changes

| change | why |
|---|---|
| `pull_request` only | GitHub runs it against the **merge result**, not the branch head, so the post-merge run on main re-audited a tree that had already passed. That duplicate was half the spend. |
| `concurrency` + `cancel-in-progress` | several pushes in quick succession each ran a full audit to completion |
| `paths-ignore` | markdown, LICENSE, `.github` — kept **deliberately conservative**, since a generated project's layout is unknown here |
| `numberOfRuns` 3 → 1 | the generated gate is `performance >= 0.5`, far too loose for run-to-run variance to flip; the median of three was paying ~45s for precision nothing consumed |
| accessibility assertion | Lighthouse computes the category anyway and the template discarded it |
| drop `dev`/`staging`/`test` branches | the template referenced branches it never scaffolds |

The accessibility assertion is **`warn`, not `error`**, on purpose — a new blocking gate at an unknown score would fail the first PR of every freshly scaffolded project.

`workflow_dispatch` keeps a manual trigger for any ref. **No `schedule`** — a cron in a scaffold would quietly spend minutes in repos that may never look at it.

## Verified by scaffolding, not by reading the template

Built the CLI and generated real projects:

- **pnpm** and **bun** variants both render **valid YAML** (parsed, not eyeballed)
- `${{ github.ref }}` and `${{ secrets.LHCI_GITHUB_APP_TOKEN }}` survive Go templating intact — the concurrency group needed `{{ "${{ github.ref }}" }}` escaping to get there
- **no unrendered `{{ . }}` tags** remain in either output
- `go build ./...` and `go test ./...` pass

The same fix is applied to osbrjp/osbrjp-v2, the repo this template generated the offending config into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)