### PR TITLE
ci(templates): audit only the pages a PR affects in the LHCI workflow

### DIFF
--- a/config/templates/audit/lhci/.github/workflows/lhci.yml.tmpl
+++ b/config/templates/audit/lhci/.github/workflows/lhci.yml.tmpl
@@ -1,3 +1,4 @@
+{{- $urls := "" }}{{- if not .Base.IsVite }}{{- $urls = " ${{ steps.affected.outputs.urls }}" }}{{- end -}}
 name: Lighthouse CI
 
 # Pull requests only. GitHub runs this against the merge result rather than the branch
@@ -27,6 +28,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+{{- if not .Base.IsVite }}
+      # A PR that only touches static page files can't change any other route's
+      # score, so audit just those routes instead of the full lighthouserc list.
+      # Anything shared (components, layouts, config), dynamic routes ([slug]),
+      # underscore partials, and non-HTML endpoints (rss.xml.ts) fall back to
+      # the full audit — narrowing must never skip a route a change could regress.
+      - name: Limit audit to changed pages
+        id: affected
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: {{ "${{ github.event.pull_request.base.sha }}" }}
+        run: |
+          pages_dir="{{ if .Base.IsNuxt }}app/pages{{ else }}src/pages{{ end }}"
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          urls=""
+          while IFS= read -r f; do
+            case "$f" in
+              "$pages_dir"/_* | "$pages_dir"/*/_* | "$pages_dir"/*\[* | "$pages_dir"/*.*.*)
+                urls=""; break ;;
+              "$pages_dir"/*)
+                route="${f#"$pages_dir"}"
+                route="${route%.*}"
+                route="${route%/index}"
+                urls="$urls --collect.url=http://localhost:3000${route:-/}"
+                ;;
+              *) urls=""; break ;;
+            esac
+          done < <(git diff --name-only --diff-filter=d "$BASE_SHA" HEAD)
+          echo "urls=$urls" >> "$GITHUB_OUTPUT"
+{{- end }}
 {{- if eq .PM "pnpm" }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
@@ -35,14 +66,14 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm run build
-      - run: pnpx lhci autorun
+      - run: pnpx lhci autorun{{ $urls }}
         env:
           LHCI_GITHUB_APP_TOKEN: {{ "${{ secrets.LHCI_GITHUB_APP_TOKEN }}" }}
 {{- else if eq .PM "bun" }}
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run build
-      - run: bunx lhci autorun
+      - run: bunx lhci autorun{{ $urls }}
         env:
           LHCI_GITHUB_APP_TOKEN: {{ "${{ secrets.LHCI_GITHUB_APP_TOKEN }}" }}
 {{- else if eq .PM "yarn" }}
@@ -52,7 +83,7 @@ jobs:
           cache: yarn
       - run: yarn install
       - run: yarn build
-      - run: yarn dlx @lhci/cli@0.15.x autorun
+      - run: yarn dlx @lhci/cli@0.15.x autorun{{ $urls }}
         env:
           LHCI_GITHUB_APP_TOKEN: {{ "${{ secrets.LHCI_GITHUB_APP_TOKEN }}" }}
 {{- else }}
@@ -62,7 +93,7 @@ jobs:
           cache: npm
       - run: npm install
       - run: npm run build
-      - run: npx --package=@lhci/cli@0.15.x lhci autorun
+      - run: npx --package=@lhci/cli@0.15.x lhci autorun{{ $urls }}
         env:
           LHCI_GITHUB_APP_TOKEN: {{ "${{ secrets.LHCI_GITHUB_APP_TOKEN }}" }}
 {{- end }}

--- a/pkg/render_test.go
+++ b/pkg/render_test.go
@@ -45,6 +45,16 @@ func TestScaffoldRenders(t *testing.T) {
 		return c
 	}
 	plainAstro := func() ProjectConfig { return NewProjectConfig() }
+	lhciAstro := func() ProjectConfig {
+		c := NewProjectConfig()
+		c.Audit = "lhci"
+		return c
+	}
+	lhciNuxt := func() ProjectConfig {
+		c := NewProjectConfig()
+		c.Base, c.Audit = "nuxt", "lhci"
+		return c
+	}
 
 	cases := []struct {
 		name string
@@ -88,6 +98,21 @@ func TestScaffoldRenders(t *testing.T) {
 			name:   "plain_astro",
 			cfg:    plainAstro(),
 			absent: []string{".mcp.json", "docker-compose.yml", "apps/api/db/seed.ts"},
+		},
+		{
+			name:    "lhci_astro",
+			cfg:     lhciAstro(),
+			present: []string{"lighthouserc.json"},
+			contains: map[string][]string{
+				".github/workflows/lhci.yml": {`pages_dir="src/pages"`, "steps.affected.outputs.urls"},
+			},
+		},
+		{
+			name: "lhci_nuxt",
+			cfg:  lhciNuxt(),
+			contains: map[string][]string{
+				".github/workflows/lhci.yml": {`pages_dir="app/pages"`, "steps.affected.outputs.urls"},
+			},
 		},
 	}
 


### PR DESCRIPTION
Closes #113

## What

Adds a `Limit audit to changed pages` step to the scaffolded Lighthouse CI workflow. On pull requests it diffs against the PR base sha and, when **every** changed file is a static page file, passes only those routes to `lhci autorun` via repeated `--collect.url` flags — overriding the full URL list in `lighthouserc.json`.

- Astro bases map `src/pages/**`, Nuxt maps `app/pages/**` (`about.astro` → `/about`, `blog/index.astro` → `/blog`, `index.*` → `/`).
- Conservative fallbacks to the **full** configured audit — narrowing must never skip a route a change could regress:
  - any changed file outside the pages dir (components, layouts, config)
  - dynamic routes (`[slug]`)
  - underscore partials (`_partial.astro`)
  - non-HTML endpoints (`rss.xml.ts`)
  - deleted files are excluded from mapping (`--diff-filter=d`)
- Vite bases are single-URL SPAs, so they render without the step and keep the plain `autorun`.
- `workflow_dispatch` runs skip the step and audit everything.

## Why

The scaffolded LHCI workflow is the org's top GHA consumer. #112 removed duplicate/stale runs; this narrows the surviving runs so page-only PRs (the common case on content-heavy sites) collect 1–2 URLs instead of the whole list.

## Testing

- `go test ./...` passes, including two new `TestScaffoldRenders` cases asserting the rendered workflow carries the right pages dir per base (`src/pages` / `app/pages`).
- Scaffolded astro, nuxt, and vite-react projects; all three rendered workflows parse as valid YAML, and the embedded script passes `bash -n`.
- Exercised the route-mapping logic against 13 sample diffs (index/nested/multi-page, shared file, dynamic route, partials, endpoints, empty diff) — all map or fall back as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)