### PR TITLE
feat: add command — apply preset templates to an existing repo

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -21,7 +21,8 @@ touching your code.
 Renders the option's config templates into the project (existing files are
 NEVER overwritten — they are skipped and reported) and additively merges the
 option's dependencies and scripts into package.json (existing versions and
-scripts are never changed; other package.json fields are preserved).
+scripts are never changed; other package.json fields, key order, and the
+file's own indent style are preserved).
 
 GitHub Actions workflow files (.github/**) are always written to the git
 repository root, even when adding inside a subdirectory such as apps/web.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -23,10 +23,13 @@ NEVER overwritten — they are skipped and reported) and additively merges the
 option's dependencies and scripts into package.json (existing versions and
 scripts are never changed; other package.json fields are preserved).
 
+GitHub Actions workflow files (.github/**) are always written to the git
+repository root, even when adding inside a subdirectory such as apps/web.
+
 The package manager is detected from package.json's packageManager field or
-the lockfile, and the base framework from package.json dependencies; use
---pm / --base to override. Run "bungkus-cli add" with no option to list what
-can be added.`,
+a lockfile (searched upward to the git root), and the base framework from
+package.json dependencies; use --pm / --base to override. Run "bungkus-cli
+add" with no option to list what can be added.`,
 	Args: cobra.MaximumNArgs(2),
 	RunE: runAdd,
 }
@@ -109,7 +112,11 @@ func runAdd(cmd *cobra.Command, args []string) error {
 func printAddReport(rep *pkg.AddReport, dir, opt string, cfg pkg.ProjectConfig) {
 	fmt.Printf("Added %s (%s) to %s\n\n", opt, strings.Join(rep.Categories, ", "), dir)
 	for _, f := range rep.CreatedFiles {
-		fmt.Printf("  created   %s\n", f)
+		if strings.HasPrefix(f, "..") {
+			fmt.Printf("  created   %s   (repo root)\n", f)
+		} else {
+			fmt.Printf("  created   %s\n", f)
+		}
 	}
 	for _, f := range rep.SkippedFiles {
 		fmt.Printf("  skipped   %s (already exists — kept yours)\n", f)
@@ -130,14 +137,16 @@ func printAddReport(rep *pkg.AddReport, dir, opt string, cfg pkg.ProjectConfig) 
 		}
 	}
 
-	// GitHub only runs workflows from the repo root's .github/workflows/.
-	for _, f := range rep.CreatedFiles {
-		if strings.HasPrefix(filepath.ToSlash(f), ".github/") {
-			if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
-				fmt.Println("\n  warning: .github/ files were created in a directory that is not a git")
-				fmt.Println("  repository root — GitHub only runs workflows from the repo root.")
+	if rep.WorkflowRelocated {
+		fmt.Printf("\n  note: workflow(s) written to %s/.github — review job steps if this is a monorepo.\n", rep.GitRoot)
+	}
+	if rep.NoGitWarning {
+		for _, f := range rep.CreatedFiles {
+			if strings.HasPrefix(filepath.ToSlash(f), ".github/") {
+				fmt.Printf("\n  warning: no git repository found — .github/ written under %s;\n", dir)
+				fmt.Println("  GitHub Actions only reads .github/ at the repo root.")
+				break
 			}
-			break
 		}
 	}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spencer-osbrjp/bungkus-cli/config"
+	"github.com/spencer-osbrjp/bungkus-cli/pkg"
+	"github.com/spf13/cobra"
+)
+
+var addCmd = &cobra.Command{
+	Use:   "add <option> [dir]",
+	Short: "Add a tool to an existing project.",
+	Long: `Add a tool from the bungkus registry to an existing project without
+touching your code.
+
+Renders the option's config templates into the project (existing files are
+NEVER overwritten — they are skipped and reported) and additively merges the
+option's dependencies and scripts into package.json (existing versions and
+scripts are never changed; other package.json fields are preserved).
+
+The package manager is detected from package.json's packageManager field or
+the lockfile, and the base framework from package.json dependencies; use
+--pm / --base to override. Run "bungkus-cli add" with no option to list what
+can be added.`,
+	Args: cobra.MaximumNArgs(2),
+	RunE: runAdd,
+}
+
+func init() {
+	rootCmd.AddCommand(addCmd)
+	addCmd.Flags().String("pm", "", "Package manager override (pnpm, bun, npm, yarn); detected otherwise")
+	addCmd.Flags().String("base", "", "Base framework override; detected from package.json otherwise")
+	addCmd.Flags().String("deploy", "", "Deploy target for CI/CD options (cloudflare-pages, cloudflare-workers)")
+}
+
+func printAddable() {
+	fmt.Println("Addable options:")
+	for _, c := range pkg.AddableOptions() {
+		fmt.Printf("  %-8s %s\n", c.Name+":", strings.Join(c.Options, ", "))
+	}
+	fmt.Println("\ncicd options require --deploy.")
+}
+
+func runAdd(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		printAddable()
+		return nil
+	}
+	opt := args[0]
+	dir := "."
+	if len(args) == 2 {
+		dir = args[1]
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return fmt.Errorf("no package.json found in %s — 'add' works on an existing project (use 'create' to scaffold a new one)", dir)
+	}
+	cfg, err := pkg.DetectProject(dir, raw)
+	if err != nil {
+		return err
+	}
+	if cmd.Flags().Changed("pm") {
+		v, _ := cmd.Flags().GetString("pm")
+		cfg.PM = pkg.PackageManager(v)
+	}
+	if cmd.Flags().Changed("base") {
+		v, _ := cmd.Flags().GetString("base")
+		cfg.Base = pkg.BaseFramework(v)
+	}
+	if cmd.Flags().Changed("deploy") {
+		v, _ := cmd.Flags().GetString("deploy")
+		cfg.Deployment = pkg.DeployTarget(v)
+	}
+	if cfg.PM == "" {
+		return fmt.Errorf("could not detect the package manager (no or ambiguous lockfile) — pass --pm (pnpm, bun, npm, yarn)")
+	}
+	if !cfg.PM.IsValid() {
+		return fmt.Errorf("invalid package manager: %s (pnpm, bun, npm, yarn)", cfg.PM)
+	}
+	if cfg.Base == "" {
+		return fmt.Errorf("could not detect the base framework from package.json — pass --base (astro, astro-react, astro-vue, nuxt, vite, vite-react, vite-vue)")
+	}
+	if !cfg.Base.IsValid() {
+		return fmt.Errorf("invalid base framework: %s", cfg.Base)
+	}
+	if cfg.Deployment != "none" && !cfg.Deployment.IsValid() {
+		return fmt.Errorf("invalid deploy target: %s (cloudflare-pages, cloudflare-workers)", cfg.Deployment)
+	}
+
+	rep, err := pkg.Add(dir, config.Templates, cfg, opt)
+	if errors.Is(err, pkg.ErrUnknownAddOption) {
+		fmt.Printf("unknown option %q\n\n", opt)
+		printAddable()
+		return errors.New("nothing added")
+	}
+	if err != nil {
+		return err
+	}
+	printAddReport(rep, dir, opt, cfg)
+	return nil
+}
+
+func printAddReport(rep *pkg.AddReport, dir, opt string, cfg pkg.ProjectConfig) {
+	fmt.Printf("Added %s (%s) to %s\n\n", opt, strings.Join(rep.Categories, ", "), dir)
+	for _, f := range rep.CreatedFiles {
+		fmt.Printf("  created   %s\n", f)
+	}
+	for _, f := range rep.SkippedFiles {
+		fmt.Printf("  skipped   %s (already exists — kept yours)\n", f)
+	}
+	if len(rep.DepsAdded)+len(rep.DepsSkipped)+len(rep.ScriptsAdded)+len(rep.ScriptsSkipped) > 0 {
+		fmt.Println("\n  package.json:")
+		for _, d := range rep.DepsAdded {
+			fmt.Printf("    + %s\n", d)
+		}
+		for _, s := range rep.ScriptsAdded {
+			fmt.Printf("    + scripts  %s\n", s)
+		}
+		for _, d := range rep.DepsSkipped {
+			fmt.Printf("    = %s (already present — kept yours)\n", d)
+		}
+		for _, s := range rep.ScriptsSkipped {
+			fmt.Printf("    = scripts  %s (already defined — kept yours)\n", s)
+		}
+	}
+
+	// GitHub only runs workflows from the repo root's .github/workflows/.
+	for _, f := range rep.CreatedFiles {
+		if strings.HasPrefix(filepath.ToSlash(f), ".github/") {
+			if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+				fmt.Println("\n  warning: .github/ files were created in a directory that is not a git")
+				fmt.Println("  repository root — GitHub only runs workflows from the repo root.")
+			}
+			break
+		}
+	}
+
+	if rep.PkgJSONChanged {
+		fmt.Printf("\nRun `%s` to install the new dependencies.\n", cfg.PM.InstallCmd())
+	} else if len(rep.CreatedFiles) == 0 {
+		fmt.Printf("\nNothing to do — everything %s provides already exists.\n", opt)
+	}
+}

--- a/pkg/add.go
+++ b/pkg/add.go
@@ -14,13 +14,16 @@ import (
 var ErrUnknownAddOption = errors.New("unknown add option")
 
 // AddReport records what Add did (and refused to do). File paths are relative
-// to the project directory.
+// to the project directory (relocated workflow files may contain "../").
 type AddReport struct {
 	CreatedFiles, SkippedFiles   []string
 	DepsAdded, DepsSkipped       []string
 	ScriptsAdded, ScriptsSkipped []string
 	PkgJSONChanged               bool
 	Categories                   []string
+	GitRoot                      string // where .github/** is written
+	NoGitWarning                 bool   // no .git found walking up from dir
+	WorkflowRelocated            bool   // .github/** landed outside dir
 }
 
 // addCategory wires one registry category into `add`. Options inside each
@@ -121,7 +124,45 @@ func DetectProject(dir string, rawPkg []byte) (ProjectConfig, error) {
 	} else {
 		cfg.CSS = "vanilla"
 	}
+	cfg.Deployment = detectDeploy(dir)
 	return cfg, nil
+}
+
+// detectDeploy infers the deploy target from an existing wrangler config so
+// `add cloudflare-pages` followed by `add github-actions` needs no flags.
+// ponytail: heuristic tied to the two current registry targets — only the
+// pages template carries pages_build_output_dir.
+func detectDeploy(dir string) DeployTarget {
+	for _, f := range []string{"wrangler.jsonc", "wrangler.toml"} {
+		data, err := os.ReadFile(filepath.Join(dir, f))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), "pages_build_output_dir") {
+			return "cloudflare-pages"
+		}
+		return "cloudflare-workers"
+	}
+	return "none"
+}
+
+// findGitRoot walks up from dir to the nearest ancestor containing .git (a
+// directory, or a file in worktrees). Returns "" when there is none.
+func findGitRoot(dir string) string {
+	d, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return ""
+		}
+		d = parent
+	}
 }
 
 // detectPM resolves the package manager: package.json's packageManager field
@@ -239,9 +280,16 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 	}
 	for _, cat := range matched {
 		if cat.name == "cicd" && cfg.Deployment == "none" {
-			return nil, fmt.Errorf("%s needs a deploy target: pass --deploy (cloudflare-pages, cloudflare-workers)", opt)
+			return nil, fmt.Errorf("%s needs a deploy target: pass --deploy (cloudflare-pages, cloudflare-workers) or run 'bungkus-cli add cloudflare-pages' first", opt)
 		}
 		cat.set(&cfg, opt)
+	}
+
+	// GitHub only reads .github/ at the repo root, so workflow templates are
+	// redirected there (copyDir handles the redirect via rep.GitRoot).
+	if rep.GitRoot = findGitRoot(dir); rep.GitRoot == "" {
+		rep.NoGitWarning = true
+		rep.GitRoot, _ = filepath.Abs(dir)
 	}
 
 	for _, cat := range matched {
@@ -284,11 +332,18 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 		}
 	}
 
+	absDir, _ := filepath.Abs(dir)
 	rel := func(paths []string) []string {
 		out := make([]string, 0, len(paths))
 		for _, p := range paths {
-			if r, err := filepath.Rel(dir, p); err == nil {
+			if abs, err := filepath.Abs(p); err == nil {
+				p = abs
+			}
+			if r, err := filepath.Rel(absDir, p); err == nil {
 				out = append(out, r)
+				if strings.HasPrefix(r, "..") {
+					rep.WorkflowRelocated = true
+				}
 			} else {
 				out = append(out, p)
 			}

--- a/pkg/add.go
+++ b/pkg/add.go
@@ -1,0 +1,314 @@
+package pkg
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrUnknownAddOption is returned when the option matches no addable category.
+var ErrUnknownAddOption = errors.New("unknown add option")
+
+// AddReport records what Add did (and refused to do). File paths are relative
+// to the project directory.
+type AddReport struct {
+	CreatedFiles, SkippedFiles   []string
+	DepsAdded, DepsSkipped       []string
+	ScriptsAdded, ScriptsSkipped []string
+	PkgJSONChanged               bool
+	Categories                   []string
+}
+
+// addCategory wires one registry category into `add`. Options inside each
+// category are 100% registry-driven; only the category list is Go-known,
+// mirroring the per-category branches in Scaffold/BuildPackageJSON. The
+// supported set is the standalone categories (config files + deps, no source
+// edits inside the user's app).
+type addCategory struct {
+	name   string // registry/template dir name
+	lookup func(*Registry, string) *OptionEntry
+	set    func(*ProjectConfig, string)
+}
+
+var addCategories = []addCategory{
+	{"fmt", (*Registry).GetFormatter, func(c *ProjectConfig, v string) { c.Fmt = Formatter(v) }},
+	{"linter", (*Registry).GetLinter, func(c *ProjectConfig, v string) { c.Linter = Linter(v) }},
+	{"test", (*Registry).GetTestingFramework, func(c *ProjectConfig, v string) { c.Test = TestingFramework(v) }},
+	{"audit", (*Registry).GetAudit, func(c *ProjectConfig, v string) { c.Audit = AuditTool(v) }},
+	{"deploy", (*Registry).GetDeployment, func(c *ProjectConfig, v string) { c.Deployment = DeployTarget(v) }},
+	{"cicd", (*Registry).GetCICD, func(c *ProjectConfig, v string) { c.CICD = CICDProvider(v) }},
+}
+
+// AddableCategory is one row of the `add` help listing.
+type AddableCategory struct {
+	Name    string
+	Options []string
+}
+
+// AddableOptions lists what `add` accepts, generated from the live registry so
+// the listing can never go stale.
+func AddableOptions() []AddableCategory {
+	r := GetRegistry()
+	cats := []struct {
+		name    string
+		entries []OptionEntry
+	}{
+		{"fmt", r.Formatters}, {"linter", r.Linters}, {"test", r.Test},
+		{"audit", r.Audit}, {"deploy", r.Deployment}, {"cicd", r.CICD},
+	}
+	out := make([]AddableCategory, 0, len(cats))
+	for _, c := range cats {
+		var opts []string
+		for _, e := range c.entries {
+			if e.Value != "none" {
+				opts = append(opts, e.Value)
+			}
+		}
+		out = append(out, AddableCategory{c.name, opts})
+	}
+	return out
+}
+
+// lockfileNames maps each package manager to its lockfile names. These are npm
+// ecosystem facts, not bungkus choices, so they live here, not in the registry.
+var lockfileNames = map[string][]string{
+	"pnpm": {"pnpm-lock.yaml"},
+	"bun":  {"bun.lock", "bun.lockb"},
+	"npm":  {"package-lock.json"},
+	"yarn": {"yarn.lock"},
+}
+
+// DetectProject inspects dir and rawPkg (the project's package.json bytes) and
+// returns a partial ProjectConfig. Base and PM are left empty when they cannot
+// be determined unambiguously, for the caller to fill from flags or reject.
+// Fmt/Linter are left empty so only the option being added triggers
+// cross-cutting package rules.
+func DetectProject(dir string, rawPkg []byte) (ProjectConfig, error) {
+	cfg := NewProjectConfig()
+	cfg.Base, cfg.PM, cfg.Fmt, cfg.Linter = "", "", "", ""
+
+	var pj struct {
+		Name            string            `json:"name"`
+		PackageManager  string            `json:"packageManager"`
+		Dependencies    map[string]string `json:"dependencies"`
+		DevDependencies map[string]string `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(rawPkg, &pj); err != nil {
+		return cfg, fmt.Errorf("could not parse package.json: %w", err)
+	}
+	if pj.Name != "" {
+		cfg.ProjectName = pj.Name
+	} else if abs, err := filepath.Abs(dir); err == nil {
+		cfg.ProjectName = filepath.Base(abs)
+	}
+
+	names := map[string]bool{}
+	for k := range pj.Dependencies {
+		names[k] = true
+	}
+	for k := range pj.DevDependencies {
+		names[k] = true
+	}
+
+	cfg.PM = detectPM(dir, pj.PackageManager)
+	cfg.Base = BaseFramework(detectBase(names))
+	if names["tailwindcss"] {
+		cfg.CSS = "tailwindcss"
+	} else {
+		cfg.CSS = "vanilla"
+	}
+	return cfg, nil
+}
+
+// detectPM resolves the package manager: package.json's packageManager field
+// wins; otherwise walk up from dir looking for exactly one PM's lockfile,
+// stopping at the repo root (a directory containing .git). Zero or several
+// matching lockfiles yield "" so the caller can require --pm.
+func detectPM(dir, pmField string) PackageManager {
+	if name, _, _ := strings.Cut(pmField, "@"); name != "" && GetRegistry().HasPM(name) {
+		return PackageManager(name)
+	}
+	d, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	for {
+		var found []string
+		for pm, files := range lockfileNames {
+			for _, f := range files {
+				if _, err := os.Stat(filepath.Join(d, f)); err == nil {
+					found = append(found, pm)
+					break
+				}
+			}
+		}
+		if len(found) == 1 {
+			return PackageManager(found[0])
+		}
+		if len(found) > 1 {
+			return "" // ambiguous
+		}
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return "" // repo root reached, no lockfile anywhere
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return ""
+		}
+		d = parent
+	}
+}
+
+// detectBase matches the dependency-name signature of every registry base: a
+// base is a candidate when all of its packages appear among the project's
+// dependency names. The candidate with the most packages wins (astro-react
+// beats astro); a tie is ambiguous and yields "".
+func detectBase(names map[string]bool) string {
+	best, bestCount, tie := "", 0, false
+	for _, b := range GetRegistry().Bases {
+		count := len(b.Packages.Dependencies) + len(b.Packages.DevDependencies)
+		if count == 0 {
+			continue
+		}
+		ok := true
+		for k := range b.Packages.Dependencies {
+			if !names[k] {
+				ok = false
+				break
+			}
+		}
+		for k := range b.Packages.DevDependencies {
+			if !ok || !names[k] {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		switch {
+		case count > bestCount:
+			best, bestCount, tie = b.Value, count, false
+		case count == bestCount:
+			tie = true
+		}
+	}
+	if tie {
+		return ""
+	}
+	return best
+}
+
+// Add applies option opt to the existing project at dir. cfg is the detected/
+// overridden project config (Base and PM must be valid). It renders each
+// matched category's templates without ever overwriting an existing file,
+// merges the option's packages into package.json additively, and returns a
+// report of everything it did. The only file ever rewritten is package.json.
+func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport, error) {
+	reg := GetRegistry()
+	baseEntry := reg.GetBase(string(cfg.Base))
+	if baseEntry == nil {
+		return nil, fmt.Errorf("unknown base framework: %s", cfg.Base)
+	}
+	if opt == "none" {
+		return nil, ErrUnknownAddOption
+	}
+
+	rep := &AddReport{}
+	var entries []*OptionEntry
+	var matched []addCategory
+	for _, cat := range addCategories {
+		if e := cat.lookup(reg, opt); e != nil {
+			entries = append(entries, e)
+			matched = append(matched, cat)
+			rep.Categories = append(rep.Categories, cat.name)
+		}
+	}
+	if len(entries) == 0 {
+		return nil, ErrUnknownAddOption
+	}
+
+	for _, e := range entries {
+		if e.ExcludesGroup(baseEntry.Group) {
+			return nil, fmt.Errorf("%s does not support %s projects", opt, baseEntry.Group)
+		}
+	}
+	for _, cat := range matched {
+		if cat.name == "cicd" && cfg.Deployment == "none" {
+			return nil, fmt.Errorf("%s needs a deploy target: pass --deploy (cloudflare-pages, cloudflare-workers)", opt)
+		}
+		cat.set(&cfg, opt)
+	}
+
+	for _, cat := range matched {
+		tmplDir := "templates/" + cat.name + "/" + opt
+		if cat.name == "cicd" {
+			tmplDir = "templates/cicd/" + opt + "/" + string(cfg.Deployment)
+		}
+		if _, err := fs.Stat(templates, tmplDir); err != nil {
+			continue // deps-only option, no template dir
+		}
+		sub, err := fs.Sub(templates, tmplDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s templates: %w", cat.name, err)
+		}
+		if err := copyDir(sub, dir, cfg, "", rep); err != nil {
+			return nil, err
+		}
+	}
+	// Playwright ships the agent MCP config too, same as create.
+	if cfg.Test == "playwright" {
+		if sub, err := fs.Sub(templates, "templates/agent/mcp"); err == nil {
+			if err := copyDir(sub, dir, cfg, "", rep); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	pkgPath := filepath.Join(dir, "package.json")
+	raw, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read package.json: %w", err)
+	}
+	merged, err := MergeAddPackages(raw, collectAddPackages(cfg, entries), rep)
+	if err != nil {
+		return nil, err
+	}
+	if rep.PkgJSONChanged {
+		if err := os.WriteFile(pkgPath, merged, 0o644); err != nil {
+			return nil, err
+		}
+	}
+
+	rel := func(paths []string) []string {
+		out := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if r, err := filepath.Rel(dir, p); err == nil {
+				out = append(out, r)
+			} else {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	rep.CreatedFiles, rep.SkippedFiles = rel(rep.CreatedFiles), rel(rep.SkippedFiles)
+	return rep, nil
+}
+
+// collectAddPackages builds the packages an add contributes: each matched
+// entry's own packages plus the cross-cutting rules evaluated against the
+// detected config (e.g. `add prettier` on a tailwind project also brings
+// prettier-plugin-tailwindcss). Reuses the create path's rule code so version
+// literals are never duplicated.
+func collectAddPackages(cfg ProjectConfig, entries []*OptionEntry) Packages {
+	p := packageJSON{Scripts: map[string]string{}, Dependencies: map[string]string{}, DevDependencies: map[string]string{}}
+	for _, e := range entries {
+		mergePackages(&p, e.Packages)
+	}
+	applyCrossCuttingRules(&p, cfg)
+	return Packages{Scripts: p.Scripts, Dependencies: p.Dependencies, DevDependencies: p.DevDependencies}
+}

--- a/pkg/add.go
+++ b/pkg/add.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -76,6 +77,9 @@ func AddableOptions() []AddableCategory {
 	return out
 }
 
+// wranglerTomlMainRE matches a top-level `main = ...` in wrangler.toml.
+var wranglerTomlMainRE = regexp.MustCompile(`(?m)^\s*main\s*=`)
+
 // lockfileNames maps each package manager to its lockfile names. These are npm
 // ecosystem facts, not bungkus choices, so they live here, not in the registry.
 var lockfileNames = map[string][]string{
@@ -130,32 +134,50 @@ func DetectProject(dir string, rawPkg []byte) (ProjectConfig, error) {
 
 // detectDeploy infers the deploy target from an existing wrangler config so
 // `add cloudflare-pages` followed by `add github-actions` needs no flags.
-// ponytail: heuristic tied to the two current registry targets — only the
-// pages template carries pages_build_output_dir.
+// Deliberately conservative: each target needs its own positive marker
+// (pages_build_output_dir / main); anything else stays "none" and the caller
+// asks for --deploy rather than guessing a workflow that deploys wrongly.
 func detectDeploy(dir string) DeployTarget {
 	for _, f := range []string{"wrangler.jsonc", "wrangler.toml"} {
 		data, err := os.ReadFile(filepath.Join(dir, f))
 		if err != nil {
 			continue
 		}
-		if strings.Contains(string(data), "pages_build_output_dir") {
+		s := string(data)
+		switch {
+		case strings.Contains(s, "pages_build_output_dir"):
 			return "cloudflare-pages"
+		case strings.Contains(s, `"main"`) || wranglerTomlMainRE.MatchString(s):
+			return "cloudflare-workers"
 		}
-		return "cloudflare-workers"
+		return "none"
 	}
 	return "none"
 }
 
 // findGitRoot walks up from dir to the nearest ancestor containing .git (a
-// directory, or a file in worktrees). Returns "" when there is none.
+// directory, or a file in worktrees). Unless that ancestor is dir itself it
+// must also look like a JS workspace root (package.json or
+// pnpm-workspace.yaml) — otherwise an unrelated outer repo (e.g. a
+// git-managed $HOME) would receive this project's workflow files or lend it
+// a stray lockfile. Returns "" when there is no usable root.
 func findGitRoot(dir string) string {
 	d, err := filepath.Abs(dir)
 	if err != nil {
 		return ""
 	}
+	start := d
 	for {
 		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
-			return d
+			if d == start {
+				return d
+			}
+			for _, marker := range []string{"package.json", "pnpm-workspace.yaml"} {
+				if _, err := os.Stat(filepath.Join(d, marker)); err == nil {
+					return d
+				}
+			}
+			return ""
 		}
 		parent := filepath.Dir(d)
 		if parent == d {
@@ -166,9 +188,11 @@ func findGitRoot(dir string) string {
 }
 
 // detectPM resolves the package manager: package.json's packageManager field
-// wins; otherwise walk up from dir looking for exactly one PM's lockfile,
-// stopping at the repo root (a directory containing .git). Zero or several
-// matching lockfiles yield "" so the caller can require --pm.
+// wins; otherwise look for exactly one PM's lockfile, walking up from dir but
+// never past the project's own git root (see findGitRoot). Without a usable
+// git root only dir itself is checked — walking further would adopt stray
+// lockfiles from unrelated ancestors. Zero or several matching lockfiles
+// yield "" so the caller can require --pm.
 func detectPM(dir, pmField string) PackageManager {
 	if name, _, _ := strings.Cut(pmField, "@"); name != "" && GetRegistry().HasPM(name) {
 		return PackageManager(name)
@@ -177,6 +201,7 @@ func detectPM(dir, pmField string) PackageManager {
 	if err != nil {
 		return ""
 	}
+	root := findGitRoot(dir)
 	for {
 		var found []string
 		for pm, files := range lockfileNames {
@@ -193,8 +218,8 @@ func detectPM(dir, pmField string) PackageManager {
 		if len(found) > 1 {
 			return "" // ambiguous
 		}
-		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
-			return "" // repo root reached, no lockfile anywhere
+		if root == "" || d == root {
+			return ""
 		}
 		parent := filepath.Dir(d)
 		if parent == d {
@@ -278,9 +303,17 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 			return nil, fmt.Errorf("%s does not support %s projects", opt, baseEntry.Group)
 		}
 	}
+	cfgBefore := cfg
 	for _, cat := range matched {
-		if cat.name == "cicd" && cfg.Deployment == "none" {
-			return nil, fmt.Errorf("%s needs a deploy target: pass --deploy (cloudflare-pages, cloudflare-workers) or run 'bungkus-cli add cloudflare-pages' first", opt)
+		if cat.name == "cicd" {
+			if cfg.Deployment == "none" {
+				return nil, fmt.Errorf("%s needs a deploy target: pass --deploy (cloudflare-pages, cloudflare-workers) or run 'bungkus-cli add cloudflare-pages' first", opt)
+			}
+			// The rendered workflow runs wrangler; ship the deploy target's
+			// packages (wrangler devDep + deploy script) alongside it.
+			if de := reg.GetDeployment(string(cfg.Deployment)); de != nil {
+				entries = append(entries, de)
+			}
 		}
 		cat.set(&cfg, opt)
 	}
@@ -290,6 +323,18 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 	if rep.GitRoot = findGitRoot(dir); rep.GitRoot == "" {
 		rep.NoGitWarning = true
 		rep.GitRoot, _ = filepath.Abs(dir)
+	}
+
+	// Merge package.json FIRST: a malformed file (e.g. "devDependencies": null)
+	// must abort before any template file lands in the user's tree.
+	pkgPath := filepath.Join(dir, "package.json")
+	raw, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read package.json: %w", err)
+	}
+	merged, err := MergeAddPackages(raw, collectAddPackages(cfgBefore, cfg, entries), rep)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, cat := range matched {
@@ -317,23 +362,21 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 		}
 	}
 
-	pkgPath := filepath.Join(dir, "package.json")
-	raw, err := os.ReadFile(pkgPath)
-	if err != nil {
-		return nil, fmt.Errorf("could not read package.json: %w", err)
-	}
-	merged, err := MergeAddPackages(raw, collectAddPackages(cfg, entries), rep)
-	if err != nil {
-		return nil, err
-	}
+	// Atomic replace: a crash or full disk mid-write must never truncate the
+	// user's package.json (the one pre-existing file this command rewrites).
 	if rep.PkgJSONChanged {
-		if err := os.WriteFile(pkgPath, merged, 0o644); err != nil {
+		tmp := pkgPath + ".bungkus.tmp"
+		if err := os.WriteFile(tmp, merged, 0o644); err != nil {
+			return nil, err
+		}
+		if err := os.Rename(tmp, pkgPath); err != nil {
+			os.Remove(tmp)
 			return nil, err
 		}
 	}
 
 	absDir, _ := filepath.Abs(dir)
-	rel := func(paths []string) []string {
+	rel := func(paths []string, markRelocated bool) []string {
 		out := make([]string, 0, len(paths))
 		for _, p := range paths {
 			if abs, err := filepath.Abs(p); err == nil {
@@ -341,7 +384,7 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 			}
 			if r, err := filepath.Rel(absDir, p); err == nil {
 				out = append(out, r)
-				if strings.HasPrefix(r, "..") {
+				if markRelocated && strings.HasPrefix(r, "..") {
 					rep.WorkflowRelocated = true
 				}
 			} else {
@@ -350,20 +393,39 @@ func Add(dir string, templates fs.FS, cfg ProjectConfig, opt string) (*AddReport
 		}
 		return out
 	}
-	rep.CreatedFiles, rep.SkippedFiles = rel(rep.CreatedFiles), rel(rep.SkippedFiles)
+	rep.CreatedFiles = rel(rep.CreatedFiles, true)
+	rep.SkippedFiles = rel(rep.SkippedFiles, false)
 	return rep, nil
 }
 
 // collectAddPackages builds the packages an add contributes: each matched
-// entry's own packages plus the cross-cutting rules evaluated against the
-// detected config (e.g. `add prettier` on a tailwind project also brings
-// prettier-plugin-tailwindcss). Reuses the create path's rule code so version
-// literals are never duplicated.
-func collectAddPackages(cfg ProjectConfig, entries []*OptionEntry) Packages {
+// entry's own packages plus the cross-cutting-rule DELTA the added option
+// causes (e.g. `add prettier` on a tailwind project also brings
+// prettier-plugin-tailwindcss). Rules that fire regardless of the option —
+// like pnpm+astro -> vite — are create-time concerns and must not ride along
+// on an unrelated add, so rules matched by the before-config are subtracted.
+func collectAddPackages(before, after ProjectConfig, entries []*OptionEntry) Packages {
 	p := packageJSON{Scripts: map[string]string{}, Dependencies: map[string]string{}, DevDependencies: map[string]string{}}
 	for _, e := range entries {
 		mergePackages(&p, e.Packages)
 	}
-	applyCrossCuttingRules(&p, cfg)
+
+	empty := func() packageJSON {
+		return packageJSON{Scripts: map[string]string{}, Dependencies: map[string]string{}, DevDependencies: map[string]string{}}
+	}
+	base, withOpt := empty(), empty()
+	applyCrossCuttingRules(&base, before)
+	applyCrossCuttingRules(&withOpt, after)
+	delta := func(dst, all, already map[string]string) {
+		for k, v := range all {
+			if _, ok := already[k]; !ok {
+				dst[k] = v
+			}
+		}
+	}
+	delta(p.Scripts, withOpt.Scripts, base.Scripts)
+	delta(p.Dependencies, withOpt.Dependencies, base.Dependencies)
+	delta(p.DevDependencies, withOpt.DevDependencies, base.DevDependencies)
+
 	return Packages{Scripts: p.Scripts, Dependencies: p.Dependencies, DevDependencies: p.DevDependencies}
 }

--- a/pkg/add_test.go
+++ b/pkg/add_test.go
@@ -1,0 +1,322 @@
+package pkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spencer-osbrjp/bungkus-cli/config"
+)
+
+func writeFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestDetectProject(t *testing.T) {
+	setupRegistry(t)
+
+	astroPkg := `{"name": "site", "dependencies": {"astro": "^5.0.0"}}`
+
+	cases := []struct {
+		name     string
+		pkgJSON  string
+		files    map[string]string // relative to the project dir
+		subdir   string            // detect from this subdir if set
+		wantPM   PackageManager
+		wantBase BaseFramework
+		wantCSS  CSSFramework
+		wantName string
+	}{
+		{
+			name:    "pnpm lockfile, astro base",
+			pkgJSON: astroPkg, files: map[string]string{"pnpm-lock.yaml": ""},
+			wantPM: "pnpm", wantBase: "astro", wantCSS: "vanilla", wantName: "site",
+		},
+		{
+			name:    "bun binary lockfile",
+			pkgJSON: astroPkg, files: map[string]string{"bun.lockb": ""},
+			wantPM: "bun", wantBase: "astro",
+		},
+		{
+			name:    "packageManager field beats lockfile",
+			pkgJSON: `{"name": "site", "packageManager": "yarn@4.1.0", "dependencies": {"astro": "^5.0.0"}}`,
+			files:   map[string]string{"pnpm-lock.yaml": ""},
+			wantPM:  "yarn", wantBase: "astro",
+		},
+		{
+			name:    "no lockfile means no PM",
+			pkgJSON: astroPkg, files: map[string]string{".git/HEAD": ""},
+			wantPM: "", wantBase: "astro",
+		},
+		{
+			name:    "two lockfiles are ambiguous",
+			pkgJSON: astroPkg, files: map[string]string{"pnpm-lock.yaml": "", "package-lock.json": ""},
+			wantPM: "", wantBase: "astro",
+		},
+		{
+			name:    "lockfile found in a parent workspace root",
+			pkgJSON: astroPkg,
+			files:   map[string]string{"../../pnpm-lock.yaml": "", "../../.git/HEAD": ""},
+			subdir:  "apps/web",
+			wantPM:  "pnpm", wantBase: "astro",
+		},
+		{
+			name: "astro-react beats astro",
+			pkgJSON: `{"dependencies": {"astro": "1", "@astrojs/react": "1", "react": "1", "react-dom": "1"},
+			           "devDependencies": {"@types/react": "1", "@types/react-dom": "1"}}`,
+			wantBase: "astro-react",
+		},
+		{
+			name:     "nuxt detected",
+			pkgJSON:  `{"dependencies": {"nuxt": "1", "vue": "1", "vue-router": "1"}, "devDependencies": {"@types/node": "1"}}`,
+			wantBase: "nuxt",
+		},
+		{
+			name:     "unrecognized deps mean no base",
+			pkgJSON:  `{"dependencies": {"express": "^4.0.0"}}`,
+			wantBase: "",
+		},
+		{
+			name:     "tailwind detected",
+			pkgJSON:  `{"dependencies": {"astro": "1", "tailwindcss": "^4.0.0"}}`,
+			wantBase: "astro", wantCSS: "tailwindcss",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			dir := root
+			if tc.subdir != "" {
+				dir = filepath.Join(root, tc.subdir)
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeFiles(t, dir, tc.files)
+			// Confine PM detection: without a .git the walk-up would escape the
+			// temp dir into the developer's own filesystem.
+			if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
+				writeFiles(t, root, map[string]string{".git/HEAD": ""})
+			}
+
+			cfg, err := DetectProject(dir, []byte(tc.pkgJSON))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.PM != tc.wantPM {
+				t.Errorf("PM = %q, want %q", cfg.PM, tc.wantPM)
+			}
+			if cfg.Base != tc.wantBase {
+				t.Errorf("Base = %q, want %q", cfg.Base, tc.wantBase)
+			}
+			if tc.wantCSS != "" && cfg.CSS != tc.wantCSS {
+				t.Errorf("CSS = %q, want %q", cfg.CSS, tc.wantCSS)
+			}
+			if tc.wantName != "" && cfg.ProjectName != tc.wantName {
+				t.Errorf("ProjectName = %q, want %q", cfg.ProjectName, tc.wantName)
+			}
+		})
+	}
+}
+
+func addCfg(base BaseFramework, css CSSFramework) ProjectConfig {
+	cfg := NewProjectConfig()
+	cfg.Base, cfg.PM, cfg.CSS = base, "pnpm", css
+	cfg.Fmt, cfg.Linter = "", ""
+	return cfg
+}
+
+func TestAdd(t *testing.T) {
+	setupRegistry(t)
+
+	astroPkg := `{
+  "name": "site",
+  "author": "someone",
+  "scripts": {"dev": "astro dev"},
+  "dependencies": {"astro": "^5.0.0"}
+}
+`
+
+	cases := []struct {
+		name       string
+		files      map[string]string
+		cfg        ProjectConfig
+		opt        string
+		deploy     DeployTarget
+		wantErr    string
+		created    []string
+		skipped    []string
+		pkgHas     []string
+		pkgMissing []string
+	}{
+		{
+			name: "add lhci",
+			cfg:  addCfg("astro", "vanilla"), opt: "lhci",
+			created: []string{"lighthouserc.json", ".github/workflows/lhci.yml"},
+			pkgHas:  []string{"@lhci/cli", "\"lhci\": \"lhci autorun\"", "\"author\": \"someone\""},
+		},
+		{
+			name:  "add lhci keeps an existing lighthouserc",
+			files: map[string]string{"lighthouserc.json": `{"sentinel": true}`},
+			cfg:   addCfg("astro", "vanilla"), opt: "lhci",
+			created: []string{".github/workflows/lhci.yml"},
+			skipped: []string{"lighthouserc.json"},
+		},
+		{
+			name: "add biome matches formatter and linter",
+			cfg:  addCfg("astro", "vanilla"), opt: "biome",
+			created: []string{"biome.json"},
+			pkgHas:  []string{"@biomejs/biome", "\"format\"", "\"lint\""},
+		},
+		{
+			name: "add playwright ships the mcp config too",
+			cfg:  addCfg("astro", "vanilla"), opt: "playwright",
+			created: []string{"playwright.config.ts", ".mcp.json"},
+			pkgHas:  []string{"@playwright/test", "test:e2e"},
+		},
+		{
+			name: "add prettier pulls cross-cutting plugins",
+			cfg:  addCfg("astro", "tailwindcss"), opt: "prettier",
+			pkgHas: []string{"prettier-plugin-tailwindcss", "prettier-plugin-astro"},
+		},
+		{
+			name: "add github-actions needs a deploy target",
+			cfg:  addCfg("astro", "vanilla"), opt: "github-actions",
+			wantErr: "needs a deploy target",
+		},
+		{
+			name: "add github-actions with deploy",
+			cfg:  addCfg("astro", "vanilla"), opt: "github-actions", deploy: "cloudflare-pages",
+			pkgHas: []string{"\"name\": \"site\""},
+		},
+		{
+			name: "add oxfmt on astro is rejected",
+			cfg:  addCfg("astro", "vanilla"), opt: "oxfmt",
+			wantErr: "does not support astro",
+		},
+		{
+			name: "unknown option",
+			cfg:  addCfg("astro", "vanilla"), opt: "unknown-thing",
+			wantErr: ErrUnknownAddOption.Error(),
+		},
+		{
+			name: "none is rejected",
+			cfg:  addCfg("astro", "vanilla"), opt: "none",
+			wantErr: ErrUnknownAddOption.Error(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, map[string]string{"package.json": astroPkg})
+			writeFiles(t, dir, tc.files)
+
+			cfg := tc.cfg
+			if tc.deploy != "" {
+				cfg.Deployment = tc.deploy
+			}
+			rep, err := Add(dir, config.Templates, cfg, tc.opt)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Add: %v", err)
+			}
+
+			for _, f := range tc.created {
+				if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+					t.Errorf("expected %s to be created: %v", f, err)
+				}
+			}
+			for _, f := range tc.skipped {
+				found := false
+				for _, s := range rep.SkippedFiles {
+					if filepath.ToSlash(s) == f {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected %s in SkippedFiles, got %v", f, rep.SkippedFiles)
+				}
+			}
+
+			raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(raw, new(json.RawMessage)); err != nil {
+				t.Fatalf("package.json is invalid JSON after add: %v\n%s", err, raw)
+			}
+			for _, s := range tc.pkgHas {
+				if !strings.Contains(string(raw), s) {
+					t.Errorf("package.json missing %q:\n%s", s, raw)
+				}
+			}
+			for _, s := range tc.pkgMissing {
+				if strings.Contains(string(raw), s) {
+					t.Errorf("package.json should not contain %q", s)
+				}
+			}
+		})
+	}
+}
+
+func TestAddPreservesExistingFileContent(t *testing.T) {
+	setupRegistry(t)
+	dir := t.TempDir()
+	sentinel := `{"my": "custom lighthouse config"}`
+	writeFiles(t, dir, map[string]string{
+		"package.json":      `{"name": "site", "dependencies": {"astro": "1"}}`,
+		"lighthouserc.json": sentinel,
+	})
+	if _, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "lighthouserc.json"))
+	if string(got) != sentinel {
+		t.Errorf("existing file was modified:\n%s", got)
+	}
+}
+
+func TestAddIsIdempotent(t *testing.T) {
+	setupRegistry(t)
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json": `{"name": "site", "dependencies": {"astro": "1"}}`,
+	})
+	if _, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci"); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := os.ReadFile(filepath.Join(dir, "package.json"))
+
+	rep, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.CreatedFiles) != 0 {
+		t.Errorf("second run created files: %v", rep.CreatedFiles)
+	}
+	if rep.PkgJSONChanged {
+		t.Error("second run reported package.json changes")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "package.json"))
+	if string(before) != string(after) {
+		t.Errorf("package.json changed on the second run:\nbefore: %s\nafter:  %s", before, after)
+	}
+}

--- a/pkg/add_test.go
+++ b/pkg/add_test.go
@@ -67,9 +67,19 @@ func TestDetectProject(t *testing.T) {
 		{
 			name:    "lockfile found in a parent workspace root",
 			pkgJSON: astroPkg,
-			files:   map[string]string{"../../pnpm-lock.yaml": "", "../../.git/HEAD": ""},
+			files:   map[string]string{"../../pnpm-lock.yaml": "", "../../.git/HEAD": "", "../../package.json": "{}"},
 			subdir:  "apps/web",
 			wantPM:  "pnpm", wantBase: "astro",
+		},
+		{
+			// Without a git root the walk must not leave dir: a stray lockfile
+			// in an unrelated ancestor (e.g. an accidental npm i in $HOME) must
+			// not decide the project's package manager.
+			name:    "stray parent lockfile without git is ignored",
+			pkgJSON: astroPkg,
+			files:   map[string]string{"../package-lock.json": ""},
+			subdir:  "proj",
+			wantPM:  "", wantBase: "astro",
 		},
 		{
 			name: "astro-react beats astro",
@@ -197,9 +207,12 @@ func TestAdd(t *testing.T) {
 			wantErr: "needs a deploy target",
 		},
 		{
+			// The rendered workflow runs wrangler, so the deploy target's
+			// packages must ride along or the first CI run fails.
 			name: "add github-actions with deploy",
 			cfg:  addCfg("astro", "vanilla"), opt: "github-actions", deploy: "cloudflare-pages",
-			pkgHas: []string{"\"name\": \"site\""},
+			created: []string{".github/workflows/deploy.yml"},
+			pkgHas:  []string{"wrangler", "\"deploy\""},
 		},
 		{
 			name: "add oxfmt on astro is rejected",
@@ -244,6 +257,26 @@ func TestAdd(t *testing.T) {
 					t.Errorf("expected %s to be created: %v", f, err)
 				}
 			}
+			// The same render invariants create output gets: no unrendered
+			// template residue, valid JSON — add renders with a config shape
+			// (Fmt="", Linter="") the create path never produces.
+			for _, f := range rep.CreatedFiles {
+				b, err := os.ReadFile(filepath.Join(dir, f))
+				if err != nil {
+					t.Errorf("read created file %s: %v", f, err)
+					continue
+				}
+				for _, m := range goTemplateMarkers {
+					if strings.Contains(string(b), m) {
+						t.Errorf("unrendered template marker %q in %s", m, f)
+					}
+				}
+				if strings.HasSuffix(f, ".json") {
+					if err := json.Unmarshal(b, new(json.RawMessage)); err != nil {
+						t.Errorf("invalid JSON in %s: %v", f, err)
+					}
+				}
+			}
 			for _, f := range tc.skipped {
 				found := false
 				for _, s := range rep.SkippedFiles {
@@ -281,7 +314,7 @@ func TestAddRelocatesWorkflowsToGitRoot(t *testing.T) {
 	setupRegistry(t)
 	root := t.TempDir()
 	dir := filepath.Join(root, "apps", "web")
-	writeFiles(t, root, map[string]string{".git/HEAD": ""})
+	writeFiles(t, root, map[string]string{".git/HEAD": "", "package.json": `{"name": "workspace"}`})
 	writeFiles(t, dir, map[string]string{"package.json": `{"name": "web", "dependencies": {"astro": "1"}}`})
 
 	rep, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci")
@@ -302,6 +335,77 @@ func TestAddRelocatesWorkflowsToGitRoot(t *testing.T) {
 	}
 	if rep.NoGitWarning {
 		t.Error("NoGitWarning set despite a .git at the root")
+	}
+}
+
+func TestAddIgnoresUnrelatedAncestorRepo(t *testing.T) {
+	// A git ancestor that is not a JS workspace (e.g. a git-managed $HOME) must
+	// not receive this project's workflow files.
+	setupRegistry(t)
+	root := t.TempDir()
+	dir := filepath.Join(root, "scratch", "site")
+	writeFiles(t, root, map[string]string{".git/HEAD": ""}) // no package.json at root
+	writeFiles(t, dir, map[string]string{"package.json": `{"name": "site", "dependencies": {"astro": "1"}}`})
+
+	rep, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".github")); err == nil {
+		t.Error("workflow leaked into the unrelated ancestor repo")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".github", "workflows", "lhci.yml")); err != nil {
+		t.Errorf("workflow should stay in the project dir: %v", err)
+	}
+	if !rep.NoGitWarning {
+		t.Error("NoGitWarning should be set when no usable git root exists")
+	}
+}
+
+func TestAddOnlyOptionPackages(t *testing.T) {
+	// `add lhci` on a pnpm astro project must add ONLY lhci's packages — the
+	// create-time pnpm+astro -> vite rule must not ride along.
+	setupRegistry(t)
+	dir := t.TempDir()
+	writeFiles(t, dir, map[string]string{
+		"package.json": `{"name": "site", "dependencies": {"astro": "1"}}`,
+	})
+	rep, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.DepsAdded) != 1 || !strings.HasPrefix(rep.DepsAdded[0], "@lhci/cli") {
+		t.Errorf("DepsAdded = %v, want exactly [@lhci/cli ...]", rep.DepsAdded)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "package.json"))
+	if strings.Contains(string(raw), `"vite"`) {
+		t.Errorf("unrequested vite dependency injected:\n%s", raw)
+	}
+}
+
+func TestDetectBaseTieIsAmbiguous(t *testing.T) {
+	// A project matching two equally specific base signatures (e.g. migrating
+	// between stacks) must not silently pick one.
+	setupRegistry(t)
+	reg := GetRegistry()
+	a, b := reg.GetBase("astro-react"), reg.GetBase("vite-vue")
+	count := func(e *BaseEntry) int {
+		return len(e.Packages.Dependencies) + len(e.Packages.DevDependencies)
+	}
+	if count(a) != count(b) {
+		t.Skipf("registry signatures no longer tie (%d vs %d) — pick two equal-count bases", count(a), count(b))
+	}
+	names := map[string]bool{}
+	for _, e := range []*BaseEntry{a, b} {
+		for k := range e.Packages.Dependencies {
+			names[k] = true
+		}
+		for k := range e.Packages.DevDependencies {
+			names[k] = true
+		}
+	}
+	if got := detectBase(names); got != "" {
+		t.Errorf("detectBase = %q, want \"\" for a tie", got)
 	}
 }
 
@@ -332,6 +436,9 @@ func TestDetectDeploy(t *testing.T) {
 		{"pages", map[string]string{"wrangler.jsonc": `{"pages_build_output_dir": "./dist"}`}, "cloudflare-pages"},
 		{"workers", map[string]string{"wrangler.jsonc": `{"main": "src/index.ts"}`}, "cloudflare-workers"},
 		{"workers toml", map[string]string{"wrangler.toml": `main = "src/index.ts"`}, "cloudflare-workers"},
+		// A wrangler config without a positive marker (e.g. a Pages project
+		// configured in the dashboard) must NOT be guessed as workers.
+		{"ambiguous wrangler config", map[string]string{"wrangler.toml": "name = \"site\"\ncompatibility_date = \"2026-01-01\""}, "none"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/add_test.go
+++ b/pkg/add_test.go
@@ -277,6 +277,73 @@ func TestAdd(t *testing.T) {
 	}
 }
 
+func TestAddRelocatesWorkflowsToGitRoot(t *testing.T) {
+	setupRegistry(t)
+	root := t.TempDir()
+	dir := filepath.Join(root, "apps", "web")
+	writeFiles(t, root, map[string]string{".git/HEAD": ""})
+	writeFiles(t, dir, map[string]string{"package.json": `{"name": "web", "dependencies": {"astro": "1"}}`})
+
+	rep, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".github", "workflows", "lhci.yml")); err != nil {
+		t.Errorf("workflow not at git root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".github")); err == nil {
+		t.Error("stray .github left inside the app dir")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "lighthouserc.json")); err != nil {
+		t.Errorf("lighthouserc.json should stay in the app dir: %v", err)
+	}
+	if !rep.WorkflowRelocated {
+		t.Error("WorkflowRelocated not set")
+	}
+	if rep.NoGitWarning {
+		t.Error("NoGitWarning set despite a .git at the root")
+	}
+}
+
+func TestAddWithoutGitWarns(t *testing.T) {
+	setupRegistry(t)
+	dir := t.TempDir() // no .git anywhere within the temp dir
+	writeFiles(t, dir, map[string]string{"package.json": `{"name": "site", "dependencies": {"astro": "1"}}`})
+	rep, err := Add(dir, config.Templates, addCfg("astro", "vanilla"), "lhci")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The walk-up may or may not find a .git above the temp dir on the host
+	// machine; only assert the invariant that holds either way: files exist
+	// and the report is internally consistent.
+	if rep.NoGitWarning && rep.GitRoot == "" {
+		t.Error("NoGitWarning must come with a dir fallback GitRoot")
+	}
+}
+
+func TestDetectDeploy(t *testing.T) {
+	setupRegistry(t)
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  DeployTarget
+	}{
+		{"no wrangler config", nil, "none"},
+		{"pages", map[string]string{"wrangler.jsonc": `{"pages_build_output_dir": "./dist"}`}, "cloudflare-pages"},
+		{"workers", map[string]string{"wrangler.jsonc": `{"main": "src/index.ts"}`}, "cloudflare-workers"},
+		{"workers toml", map[string]string{"wrangler.toml": `main = "src/index.ts"`}, "cloudflare-workers"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFiles(t, dir, tc.files)
+			if got := detectDeploy(dir); got != tc.want {
+				t.Errorf("detectDeploy = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAddPreservesExistingFileContent(t *testing.T) {
 	setupRegistry(t)
 	dir := t.TempDir()

--- a/pkg/jsonmerge.go
+++ b/pkg/jsonmerge.go
@@ -5,13 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"regexp"
 	"slices"
 )
 
 // orderedObj preserves top-level key order and the exact raw bytes of every
-// value, so re-emitting an untouched package.json section changes nothing the
-// user wrote. Interior bytes of untouched values are preserved verbatim; only
-// each emitted level's key/indent framing is normalized to two-space style.
+// value. Interior bytes of untouched values are preserved verbatim; each
+// emitted level's key/indent framing is re-emitted using the file's own
+// sniffed indent unit and newline style, so an untouched line normally stays
+// byte-identical (exotic per-line indentation is the one case it normalizes).
 type orderedObj struct {
 	keys []string
 	vals map[string]json.RawMessage
@@ -40,10 +42,12 @@ func parseOrderedObj(data []byte) (*orderedObj, error) {
 		if err := dec.Decode(&raw); err != nil {
 			return nil, err
 		}
-		// Duplicate keys: last value wins, the key is emitted once.
-		if _, dup := o.vals[key]; !dup {
-			o.keys = append(o.keys, key)
+		// A duplicate key means any rewrite would silently drop one of the
+		// user's values (JSON parsers keep the last one) — refuse instead.
+		if _, dup := o.vals[key]; dup {
+			return nil, fmt.Errorf("duplicate key %q — refusing to rewrite", key)
 		}
+		o.keys = append(o.keys, key)
 		o.vals[key] = raw
 	}
 	if _, err := dec.Token(); err != nil { // consume the closing brace
@@ -60,27 +64,43 @@ func (o *orderedObj) set(key string, v json.RawMessage) {
 	o.vals[key] = v
 }
 
-// marshal emits the object with two-space indentation at this level; value
-// bytes are written verbatim, preserving their interior formatting.
-func (o *orderedObj) marshal(indent string) []byte {
+// marshal emits the object using the file's own indent unit and newline style
+// (see sniffFormat); value bytes are written verbatim, preserving their
+// interior formatting. prefix is the indentation of the object's own braces.
+func (o *orderedObj) marshal(prefix, unit, nl string) []byte {
 	if len(o.keys) == 0 {
 		return []byte("{}")
 	}
 	var buf bytes.Buffer
-	buf.WriteString("{\n")
+	buf.WriteString("{" + nl)
 	for i, k := range o.keys {
 		kb, _ := json.Marshal(k)
-		buf.WriteString(indent + "  ")
+		buf.WriteString(prefix + unit)
 		buf.Write(kb)
 		buf.WriteString(": ")
 		buf.Write(bytes.TrimSpace(o.vals[k]))
 		if i < len(o.keys)-1 {
 			buf.WriteByte(',')
 		}
-		buf.WriteByte('\n')
+		buf.WriteString(nl)
 	}
-	buf.WriteString(indent + "}")
+	buf.WriteString(prefix + "}")
 	return buf.Bytes()
+}
+
+var indentRE = regexp.MustCompile(`(?m)^([ \t]+)\S`)
+
+// sniffFormat detects the file's indent unit (first indented line ≈ the
+// top-level unit) and newline style so a rewrite matches what the user wrote.
+func sniffFormat(orig []byte) (unit, nl string) {
+	unit, nl = "  ", "\n"
+	if bytes.Contains(orig, []byte("\r\n")) {
+		nl = "\r\n"
+	}
+	if m := indentRE.FindSubmatch(orig); m != nil {
+		unit = string(m[1])
+	}
+	return
 }
 
 // depSections are every package.json section that can already carry a
@@ -173,8 +193,9 @@ func MergeAddPackages(orig []byte, add Packages, rep *AddReport) ([]byte, error)
 		return orig, nil
 	}
 	rep.PkgJSONChanged = true
+	unit, nl := sniffFormat(orig)
 	for name := range changed {
-		top.set(name, sections[name].marshal("  "))
+		top.set(name, sections[name].marshal(unit, unit, nl))
 	}
-	return append(top.marshal(""), '\n'), nil
+	return append(top.marshal("", unit, nl), []byte(nl)...), nil
 }

--- a/pkg/jsonmerge.go
+++ b/pkg/jsonmerge.go
@@ -1,0 +1,180 @@
+package pkg
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// orderedObj preserves top-level key order and the exact raw bytes of every
+// value, so re-emitting an untouched package.json section changes nothing the
+// user wrote. Interior bytes of untouched values are preserved verbatim; only
+// each emitted level's key/indent framing is normalized to two-space style.
+type orderedObj struct {
+	keys []string
+	vals map[string]json.RawMessage
+}
+
+func parseOrderedObj(data []byte) (*orderedObj, error) {
+	o := &orderedObj{vals: map[string]json.RawMessage{}}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("expected a JSON object")
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected an object key")
+		}
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return nil, err
+		}
+		// Duplicate keys: last value wins, the key is emitted once.
+		if _, dup := o.vals[key]; !dup {
+			o.keys = append(o.keys, key)
+		}
+		o.vals[key] = raw
+	}
+	if _, err := dec.Token(); err != nil { // consume the closing brace
+		return nil, err
+	}
+	return o, nil
+}
+
+// set replaces an existing key's value or appends the key at the end.
+func (o *orderedObj) set(key string, v json.RawMessage) {
+	if _, ok := o.vals[key]; !ok {
+		o.keys = append(o.keys, key)
+	}
+	o.vals[key] = v
+}
+
+// marshal emits the object with two-space indentation at this level; value
+// bytes are written verbatim, preserving their interior formatting.
+func (o *orderedObj) marshal(indent string) []byte {
+	if len(o.keys) == 0 {
+		return []byte("{}")
+	}
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	for i, k := range o.keys {
+		kb, _ := json.Marshal(k)
+		buf.WriteString(indent + "  ")
+		buf.Write(kb)
+		buf.WriteString(": ")
+		buf.Write(bytes.TrimSpace(o.vals[k]))
+		if i < len(o.keys)-1 {
+			buf.WriteByte(',')
+		}
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(indent + "}")
+	return buf.Bytes()
+}
+
+// depSections are every package.json section that can already carry a
+// dependency; a package present in ANY of them is never re-added.
+var depSections = []string{"dependencies", "devDependencies", "peerDependencies", "optionalDependencies"}
+
+// MergeAddPackages additively merges add into raw package.json bytes. It never
+// changes an existing script or dependency version; a dependency already
+// present in any dependency section is skipped entirely (never duplicated or
+// moved between sections). New keys are appended in sorted order after the
+// existing ones; missing sections are created at the end of the file only when
+// they gain a key. When nothing is added the original bytes are returned
+// unchanged and rep.PkgJSONChanged stays false.
+func MergeAddPackages(orig []byte, add Packages, rep *AddReport) ([]byte, error) {
+	top, err := parseOrderedObj(orig)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse package.json: %w", err)
+	}
+
+	sections := map[string]*orderedObj{}
+	getSection := func(name string) (*orderedObj, error) {
+		if o, ok := sections[name]; ok {
+			return o, nil
+		}
+		o := &orderedObj{vals: map[string]json.RawMessage{}}
+		if raw, ok := top.vals[name]; ok {
+			var err error
+			if o, err = parseOrderedObj(raw); err != nil {
+				return nil, fmt.Errorf("package.json %q is not an object: %w", name, err)
+			}
+		}
+		sections[name] = o
+		return o, nil
+	}
+
+	present := map[string]bool{}
+	for _, name := range depSections {
+		o, err := getSection(name)
+		if err != nil {
+			return nil, err
+		}
+		for _, k := range o.keys {
+			present[k] = true
+		}
+	}
+
+	changed := map[string]bool{}
+
+	scripts, err := getSection("scripts")
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range slices.Sorted(maps.Keys(add.Scripts)) {
+		if _, ok := scripts.vals[k]; ok {
+			rep.ScriptsSkipped = append(rep.ScriptsSkipped, k)
+			continue
+		}
+		v, _ := json.Marshal(add.Scripts[k])
+		scripts.set(k, v)
+		rep.ScriptsAdded = append(rep.ScriptsAdded, k+" = "+add.Scripts[k])
+		changed["scripts"] = true
+	}
+
+	addDeps := func(section string, entries map[string]string) error {
+		o, err := getSection(section)
+		if err != nil {
+			return err
+		}
+		for _, k := range slices.Sorted(maps.Keys(entries)) {
+			if present[k] {
+				rep.DepsSkipped = append(rep.DepsSkipped, k)
+				continue
+			}
+			v, _ := json.Marshal(entries[k])
+			o.set(k, v)
+			present[k] = true
+			rep.DepsAdded = append(rep.DepsAdded, k+" "+entries[k])
+			changed[section] = true
+		}
+		return nil
+	}
+	if err := addDeps("dependencies", add.Dependencies); err != nil {
+		return nil, err
+	}
+	if err := addDeps("devDependencies", add.DevDependencies); err != nil {
+		return nil, err
+	}
+
+	if len(changed) == 0 {
+		return orig, nil
+	}
+	rep.PkgJSONChanged = true
+	for name := range changed {
+		top.set(name, sections[name].marshal("  "))
+	}
+	return append(top.marshal(""), '\n'), nil
+}

--- a/pkg/jsonmerge_test.go
+++ b/pkg/jsonmerge_test.go
@@ -1,0 +1,149 @@
+package pkg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMergeAddPackages(t *testing.T) {
+	base := `{
+  "name": "my-app",
+  "author": {
+    "name": "Spencer",
+    "url": "https://example.com"
+  },
+  "license": "MIT",
+  "scripts": {
+    "dev": "astro dev",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "astro": "^5.0.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.0.0"
+  }
+}
+`
+
+	cases := []struct {
+		name        string
+		orig        string
+		add         Packages
+		wantChanged bool
+		contains    []string
+		notContains []string
+		wantErr     bool
+	}{
+		{
+			name: "adds dep and script, preserves unknown fields",
+			orig: base,
+			add: Packages{
+				Scripts:         map[string]string{"lhci": "lhci autorun"},
+				DevDependencies: DevDependencies{"@lhci/cli": "^0.14.0"},
+			},
+			wantChanged: true,
+			contains: []string{
+				"\"lhci\": \"lhci autorun\"",
+				"\"@lhci/cli\": \"^0.14.0\"",
+				// unknown field kept verbatim, interior formatting intact
+				"\"author\": {\n    \"name\": \"Spencer\",\n    \"url\": \"https://example.com\"\n  }",
+				"\"license\": \"MIT\"",
+			},
+		},
+		{
+			name: "never changes an existing script or version",
+			orig: base,
+			add: Packages{
+				Scripts:         map[string]string{"format": "biome format ."},
+				DevDependencies: DevDependencies{"prettier": "^9.9.9"},
+			},
+			wantChanged: false,
+			contains:    []string{"prettier --write .", "\"prettier\": \"^3.0.0\""},
+			notContains: []string{"biome format .", "^9.9.9"},
+		},
+		{
+			name:        "dep in the other section is skipped, not moved or duplicated",
+			orig:        base,
+			add:         Packages{Dependencies: Dependencies{"prettier": "^9.9.9"}},
+			wantChanged: false,
+		},
+		{
+			name:        "dep in peerDependencies is skipped",
+			orig:        `{"peerDependencies": {"react": "^19.0.0"}}`,
+			add:         Packages{Dependencies: Dependencies{"react": "^18.0.0"}},
+			wantChanged: false,
+			notContains: []string{"^18.0.0"},
+		},
+		{
+			name:        "creates a missing section at the end",
+			orig:        `{"name": "x"}`,
+			add:         Packages{Scripts: map[string]string{"lhci": "lhci autorun"}},
+			wantChanged: true,
+			contains:    []string{"\"scripts\": {\n    \"lhci\": \"lhci autorun\"\n  }"},
+		},
+		{
+			name:    "malformed json errors",
+			orig:    `{"name": `,
+			add:     Packages{Scripts: map[string]string{"a": "b"}},
+			wantErr: true,
+		},
+		{
+			name:        "duplicate top-level keys are deduped on write",
+			orig:        `{"license": "MIT", "license": "ISC", "scripts": {}}`,
+			add:         Packages{Scripts: map[string]string{"lhci": "lhci autorun"}},
+			wantChanged: true,
+			contains:    []string{"\"license\": \"ISC\""},
+			notContains: []string{"\"MIT\""},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := &AddReport{}
+			out, err := MergeAddPackages([]byte(tc.orig), tc.add, rep)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MergeAddPackages: %v", err)
+			}
+			if rep.PkgJSONChanged != tc.wantChanged {
+				t.Errorf("PkgJSONChanged = %v, want %v", rep.PkgJSONChanged, tc.wantChanged)
+			}
+			if !tc.wantChanged && string(out) != tc.orig {
+				t.Errorf("no-op merge must return the input byte-identical\ngot:  %q\nwant: %q", out, tc.orig)
+			}
+			for _, s := range tc.contains {
+				if !strings.Contains(string(out), s) {
+					t.Errorf("output missing %q\n%s", s, out)
+				}
+			}
+			for _, s := range tc.notContains {
+				if strings.Contains(string(out), s) {
+					t.Errorf("output should not contain %q\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestMergeAddPackagesPreservesKeyOrder(t *testing.T) {
+	orig := `{"zebra": 1, "apple": 2, "scripts": {"z": "1", "a": "2"}}`
+	rep := &AddReport{}
+	out, err := MergeAddPackages([]byte(orig), Packages{Scripts: map[string]string{"m": "3"}}, rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if !(strings.Index(s, "zebra") < strings.Index(s, "apple") && strings.Index(s, "apple") < strings.Index(s, "scripts")) {
+		t.Errorf("top-level key order not preserved:\n%s", s)
+	}
+	// existing script order kept, new key appended after
+	if !(strings.Index(s, "\"z\"") < strings.Index(s, "\"a\"") && strings.Index(s, "\"a\"") < strings.Index(s, "\"m\"")) {
+		t.Errorf("script key order not preserved:\n%s", s)
+	}
+}

--- a/pkg/jsonmerge_test.go
+++ b/pkg/jsonmerge_test.go
@@ -89,12 +89,24 @@ func TestMergeAddPackages(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:        "duplicate top-level keys are deduped on write",
-			orig:        `{"license": "MIT", "license": "ISC", "scripts": {}}`,
-			add:         Packages{Scripts: map[string]string{"lhci": "lhci autorun"}},
-			wantChanged: true,
-			contains:    []string{"\"license\": \"ISC\""},
-			notContains: []string{"\"MIT\""},
+			// A rewrite would silently drop one of the duplicate values, so the
+			// merge must refuse rather than destroy user-written bytes.
+			name:    "duplicate top-level keys are refused",
+			orig:    `{"license": "MIT", "license": "ISC", "scripts": {}}`,
+			add:     Packages{Scripts: map[string]string{"lhci": "lhci autorun"}},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate section keys are refused",
+			orig:    `{"scripts": {"build": "tsc", "build": "vite build"}}`,
+			add:     Packages{Scripts: map[string]string{"lhci": "lhci autorun"}},
+			wantErr: true,
+		},
+		{
+			name:    "null section is rejected before anything is written",
+			orig:    `{"devDependencies": null}`,
+			add:     Packages{DevDependencies: DevDependencies{"@lhci/cli": "^0.14.0"}},
+			wantErr: true,
 		},
 	}
 
@@ -128,6 +140,37 @@ func TestMergeAddPackages(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMergeAddPackagesPreservesIndentStyle(t *testing.T) {
+	// A tab-indented package.json must stay tab-indented: untouched lines keep
+	// their exact bytes and new keys use the file's own indent unit.
+	orig := "{\n\t\"name\": \"x\",\n\t\"scripts\": {\n\t\t\"dev\": \"astro dev\"\n\t}\n}\n"
+	rep := &AddReport{}
+	out, err := MergeAddPackages([]byte(orig), Packages{Scripts: map[string]string{"lhci": "lhci autorun"}}, rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, want := range []string{"\t\"name\": \"x\"", "\t\t\"dev\": \"astro dev\"", "\t\t\"lhci\": \"lhci autorun\""} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q:\n%s", want, s)
+		}
+	}
+	if strings.Contains(s, "  \"") {
+		t.Errorf("space indentation leaked into a tab-indented file:\n%s", s)
+	}
+
+	// CRLF files keep CRLF framing.
+	crlf := "{\r\n  \"name\": \"x\"\r\n}\r\n"
+	rep = &AddReport{}
+	out, err = MergeAddPackages([]byte(crlf), Packages{Scripts: map[string]string{"a": "b"}}, rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "\r\n") || strings.Contains(strings.ReplaceAll(string(out), "\r\n", ""), "\n") {
+		t.Errorf("CRLF framing not preserved:\n%q", out)
 	}
 }
 

--- a/pkg/packagejson_test.go
+++ b/pkg/packagejson_test.go
@@ -40,12 +40,12 @@ func TestBuildPackageJSON(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		cfg        func() ProjectConfig
-		wantDep    []string // must be in dependencies
-		wantDev    []string // must be in devDependencies
-		forbidDep  []string // must NOT be in dependencies
-		forbidDev  []string // must NOT be in devDependencies
+		name      string
+		cfg       func() ProjectConfig
+		wantDep   []string // must be in dependencies
+		wantDev   []string // must be in devDependencies
+		forbidDep []string // must NOT be in dependencies
+		forbidDev []string // must NOT be in devDependencies
 	}{
 		{
 			name: "astro-react + react-hook-form + zod installs resolver",

--- a/pkg/scaffold.go
+++ b/pkg/scaffold.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -57,7 +58,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 	if entry.Group == "vite" && entry.EntryPoint != "" {
 		skip = "main.ts"
 	}
-	if err := copyDir(baseFS, webDir, cfg, skip); err != nil {
+	if err := copyDir(baseFS, webDir, cfg, skip, nil); err != nil {
 		return err
 	}
 
@@ -69,7 +70,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to read %v integration templates: %w", entry.Integration, err)
 		}
-		if err := copyDir(integrationFS, webDir, cfg, ""); err != nil {
+		if err := copyDir(integrationFS, webDir, cfg, "", nil); err != nil {
 			return err
 		}
 	}
@@ -82,7 +83,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 	}
 
 	stylesDir := filepath.Join(webDir, entry.StylesDir)
-	if err := copyDir(cssFS, stylesDir, cfg, ""); err != nil {
+	if err := copyDir(cssFS, stylesDir, cfg, "", nil); err != nil {
 		return err
 	}
 
@@ -93,7 +94,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 		return fmt.Errorf("failed to read formatter templates: %w", err)
 	}
 
-	if err := copyDir(fmtFS, webDir, cfg, ""); err != nil {
+	if err := copyDir(fmtFS, webDir, cfg, "", nil); err != nil {
 		return err
 	}
 
@@ -104,7 +105,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to read linter templates: %w", err)
 		}
-		if err := copyDir(linterFS, webDir, cfg, ""); err != nil {
+		if err := copyDir(linterFS, webDir, cfg, "", nil); err != nil {
 			return err
 		}
 	}
@@ -116,7 +117,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to read package manager templates: %w", err)
 		}
-		if err := copyDir(pmFS, destDir, cfg, ""); err != nil {
+		if err := copyDir(pmFS, destDir, cfg, "", nil); err != nil {
 			return err
 		}
 	}
@@ -128,7 +129,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read test templates: %w", err)
 			}
-			if err := copyDir(testFS, webDir, cfg, ""); err != nil {
+			if err := copyDir(testFS, webDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -141,7 +142,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read audit templates: %w", err)
 			}
-			if err := copyDir(auditFS, webDir, cfg, ""); err != nil {
+			if err := copyDir(auditFS, webDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -162,7 +163,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to read CMS templates: %w", err)
 		}
-		if err := copyDir(cmsFS, webDir, cfg, ""); err != nil {
+		if err := copyDir(cmsFS, webDir, cfg, "", nil); err != nil {
 			return err
 		}
 	}
@@ -174,7 +175,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read deployment templates: %w", err)
 			}
-			if err := copyDir(deployFS, webDir, cfg, ""); err != nil {
+			if err := copyDir(deployFS, webDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -187,7 +188,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read cicd templates: %w", err)
 			}
-			if err := copyDir(cicdFS, webDir, cfg, ""); err != nil {
+			if err := copyDir(cicdFS, webDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -200,7 +201,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read backend templates: %w", err)
 			}
-			if err := copyDir(backendFS, apiDir, cfg, ""); err != nil {
+			if err := copyDir(backendFS, apiDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -213,7 +214,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read orm templates: %w", err)
 			}
-			if err := copyDir(ormFS, apiDir, cfg, ""); err != nil {
+			if err := copyDir(ormFS, apiDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -229,7 +230,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 			if err != nil {
 				return fmt.Errorf("failed to read database templates: %w", err)
 			}
-			if err := copyDir(dbFS, destDir, cfg, ""); err != nil {
+			if err := copyDir(dbFS, destDir, cfg, "", nil); err != nil {
 				return err
 			}
 		}
@@ -240,7 +241,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to read shared templates: %w", err)
 	}
-	if err := copyDir(sharedFS, destDir, cfg, ""); err != nil {
+	if err := copyDir(sharedFS, destDir, cfg, "", nil); err != nil {
 		return err
 	}
 
@@ -251,7 +252,7 @@ func Scaffold(destDir string, templates fs.FS, cfg ProjectConfig) error {
 		if err != nil {
 			return fmt.Errorf("failed to read mcp templates: %w", err)
 		}
-		if err := copyDir(mcpFS, destDir, cfg, ""); err != nil {
+		if err := copyDir(mcpFS, destDir, cfg, "", nil); err != nil {
 			return err
 		}
 	}
@@ -280,7 +281,7 @@ func scaffoldMonorepo(destDir, apiDir string, templates fs.FS, cfg ProjectConfig
 	if err != nil {
 		return fmt.Errorf("failed to read monorepo root templates: %w", err)
 	}
-	if err := copyDir(rootFS, destDir, cfg, ""); err != nil {
+	if err := copyDir(rootFS, destDir, cfg, "", nil); err != nil {
 		return err
 	}
 
@@ -300,7 +301,7 @@ func scaffoldMonorepo(destDir, apiDir string, templates fs.FS, cfg ProjectConfig
 	if err != nil {
 		return fmt.Errorf("failed to read domain templates: %w", err)
 	}
-	if err := copyDir(domainFS, domainDir, cfg, ""); err != nil {
+	if err := copyDir(domainFS, domainDir, cfg, "", nil); err != nil {
 		return err
 	}
 
@@ -320,7 +321,7 @@ func scaffoldMonorepo(destDir, apiDir string, templates fs.FS, cfg ProjectConfig
 		if err != nil {
 			return fmt.Errorf("failed to read api templates: %w", err)
 		}
-		if err := copyDir(apiFS, apiDir, cfg, ""); err != nil {
+		if err := copyDir(apiFS, apiDir, cfg, "", nil); err != nil {
 			return err
 		}
 	}
@@ -364,7 +365,10 @@ func PostScaffold(destDir string, cfg ProjectConfig) error {
 	return nil
 }
 
-func copyDir(srcFS fs.FS, destDir string, cfg ProjectConfig, skip string) error {
+// copyDir renders/copies srcFS into destDir. A non-nil rep switches to `add`
+// semantics: existing files are never overwritten, and every write or skip is
+// recorded in the report.
+func copyDir(srcFS fs.FS, destDir string, cfg ProjectConfig, skip string, rep *AddReport) error {
 	return fs.WalkDir(srcFS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -397,14 +401,14 @@ func copyDir(srcFS fs.FS, destDir string, cfg ProjectConfig, skip string) error 
 		// Render .tmpl files, copy everything else as-is
 		if strings.HasSuffix(path, ".tmpl") {
 			destPath = strings.TrimSuffix(destPath, ".tmpl")
-			return renderTemplate(srcFS, path, destPath, cfg)
+			return renderTemplate(srcFS, path, destPath, cfg, rep)
 		}
 
-		return copyFile(srcFS, path, destPath)
+		return copyFile(srcFS, path, destPath, rep)
 	})
 }
 
-func renderTemplate(srcFS fs.FS, srcPath string, destPath string, cfg ProjectConfig) error {
+func renderTemplate(srcFS fs.FS, srcPath string, destPath string, cfg ProjectConfig, rep *AddReport) error {
 	data, err := fs.ReadFile(srcFS, srcPath)
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", srcPath, err)
@@ -441,10 +445,10 @@ func renderTemplate(srcFS fs.FS, srcPath string, destPath string, cfg ProjectCon
 		perm = 0o755
 	}
 
-	return os.WriteFile(destPath, output, perm)
+	return writeScaffoldFile(destPath, output, perm, rep)
 }
 
-func copyFile(srcFS fs.FS, srcPath string, destPath string) error {
+func copyFile(srcFS fs.FS, srcPath string, destPath string, rep *AddReport) error {
 	data, err := fs.ReadFile(srcFS, srcPath)
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", srcPath, err)
@@ -454,5 +458,30 @@ func copyFile(srcFS fs.FS, srcPath string, destPath string) error {
 		return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
 	}
 
-	return os.WriteFile(destPath, data, 0o644)
+	return writeScaffoldFile(destPath, data, 0o644, rep)
+}
+
+// writeScaffoldFile writes one scaffolded file. With a non-nil report (the
+// `add` path) an existing file is never touched — it is recorded as skipped.
+func writeScaffoldFile(destPath string, data []byte, perm os.FileMode, rep *AddReport) error {
+	if rep == nil {
+		return os.WriteFile(destPath, data, perm)
+	}
+	f, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if errors.Is(err, fs.ErrExist) {
+		rep.SkippedFiles = append(rep.SkippedFiles, destPath)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	rep.CreatedFiles = append(rep.CreatedFiles, destPath)
+	return nil
 }

--- a/pkg/scaffold.go
+++ b/pkg/scaffold.go
@@ -393,6 +393,11 @@ func copyDir(srcFS fs.FS, destDir string, cfg ProjectConfig, skip string, rep *A
 		}
 
 		destPath := filepath.Join(destDir, path)
+		// The `add` path writes .github/** at the git root — GitHub only reads
+		// workflows from the repo root's .github/, not a subdirectory's.
+		if rep != nil && rep.GitRoot != "" && strings.HasPrefix(filepath.ToSlash(path)+"/", ".github/") {
+			destPath = filepath.Join(rep.GitRoot, path)
+		}
 
 		if d.IsDir() {
 			return os.MkdirAll(destPath, 0o755)


### PR DESCRIPTION
Closes #116

## What

`bungkus-cli add <option> [dir]` applies a registry option to an **existing** project: it renders the option's templates without ever overwriting a file and additively merges its deps/scripts into package.json.

- Supported categories (registry-driven options inside each): fmt, linter, test, audit, deploy, cicd. `add biome` matches formatter+linter and applies both. `bungkus-cli add` with no args lists what's addable, generated live from the registry.
- Detection: PM from package.json's `packageManager` field or a lockfile (searched upward, never past the project's git root); base from dependency signatures (most-specific wins, ties are ambiguous); deploy target from an existing wrangler config (positive markers only). `--pm/--base/--deploy` override.
- `.github/**` is written to the git repo root (GitHub ignores workflows elsewhere), but only when that root is a plausible JS workspace — an unrelated ancestor repo never receives files.
- package.json merge is order-, indent-, and newline-preserving; existing versions/scripts are never changed; deps present in any dependency section (incl. peer/optional) are never re-added; duplicate keys are refused; the write is atomic (temp + rename).
- Never-overwrite is enforced at the file layer (`O_EXCL`) threaded through the existing `copyDir`/`renderTemplate` plumbing — `create` is unchanged (nil report).

## Review

Implemented from a critiqued design, then adversarially reviewed by a 19-agent workflow (3 lenses → per-finding verification). All 16 confirmed findings fixed in the second commit, including a critical non-atomic package.json rewrite and a spurious `vite` devDependency injected on every pnpm+astro add.

## Testing

`go test ./...` green: 40+ new table-driven cases across `add_test.go` / `jsonmerge_test.go` (detection incl. walk-up boundaries and ties, never-overwrite, idempotency, byte-preservation incl. tab/CRLF fixtures, only-the-option's-packages, workflow relocation both ways, cicd wrangler packages) plus render invariants over add output. E2E smoke: create → add lhci → re-add (all skipped, byte-identical package.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)