### PR TITLE
fix: generated eslint config only imports what package.json installs

### DIFF
--- a/config/registry.json
+++ b/config/registry.json
@@ -249,7 +249,9 @@
         },
         "devDependencies": {
           "eslint": "^10.0.0",
-          "@eslint/js": "^10.0.0"
+          "@eslint/js": "^10.0.0",
+          "globals": "^17.4.0",
+          "typescript-eslint": "^8.58.0"
         }
       }
     },

--- a/config/templates/linter/eslint/eslint.config.mjs.tmpl
+++ b/config/templates/linter/eslint/eslint.config.mjs.tmpl
@@ -1,14 +1,16 @@
 import js from '@eslint/js'
 import globals from 'globals'
+{{- if .Base.IsReactInt}}
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+{{- end}}
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
   globalIgnores(['dist']),
   {
-    files: ['**/*.{ts,tsx,vue,astro}'],
+    files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
       tseslint.configs.recommended,
@@ -23,4 +25,3 @@ export default defineConfig([
     },
   },
 ])
-

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -157,11 +157,14 @@ func (b BaseFramework) IsVite() bool {
 }
 
 func (b BaseFramework) GetIntegration() (BaseIntegration, error) {
-	if globalRegistry != nil {
+	if globalRegistry == nil {
 		return BaseIntegration(""), errors.New("unable to read registry")
 	}
 
 	entry := globalRegistry.GetBase(string(b))
+	if entry == nil {
+		return BaseIntegration(""), errors.New("unknown base framework: " + string(b))
+	}
 	return BaseIntegration(entry.Integration), nil
 }
 
@@ -182,7 +185,7 @@ func (b BaseFramework) IsVueInt() bool {
 		return false
 	}
 
-	return integration == "react"
+	return integration == "vue"
 }
 
 func (c CSSFramework) IsValid() bool {

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -146,3 +146,31 @@ func TestCrateNameAndBundleIdentifier(t *testing.T) {
 		}
 	}
 }
+
+func TestBaseIntegrationHelpers(t *testing.T) {
+	setupRegistry(t)
+	cases := []struct {
+		base  BaseFramework
+		react bool
+		vue   bool
+	}{
+		{"astro", false, false},
+		{"astro-react", true, false},
+		{"astro-vue", false, true},
+		{"vite", false, false},
+		{"vite-react", true, false},
+		{"vite-vue", false, true},
+		// nuxt's registry entry has no integration field; its vue-ness is
+		// remapped separately (see BuildPackageJSON / IsValidIntegration).
+		{"nuxt", false, false},
+		{"bogus", false, false},
+	}
+	for _, tc := range cases {
+		if got := tc.base.IsReactInt(); got != tc.react {
+			t.Errorf("%s.IsReactInt() = %v, want %v", tc.base, got, tc.react)
+		}
+		if got := tc.base.IsVueInt(); got != tc.vue {
+			t.Errorf("%s.IsVueInt() = %v, want %v", tc.base, got, tc.vue)
+		}
+	}
+}

--- a/pkg/configimports_test.go
+++ b/pkg/configimports_test.go
@@ -104,3 +104,47 @@ func TestGeneratedConfigImportsAreInstalled(t *testing.T) {
 		})
 	}
 }
+
+// TestEslintReactPluginsWired asserts the positive direction the import-vs-
+// deps guard can't see: react bases must actually get the react eslint
+// plugins (both the config imports and the installed packages), and
+// non-react bases must not. Before the GetIntegration nil-check fix,
+// IsReactInt always returned false and this wiring silently never fired.
+func TestEslintReactPluginsWired(t *testing.T) {
+	setupRegistry(t)
+	scaffoldEslint := func(base BaseFramework) (conf, pkgJSON string) {
+		c := NewProjectConfig()
+		c.Base, c.Fmt, c.Linter = base, "prettier", "eslint"
+		dir := t.TempDir()
+		if err := Scaffold(dir, config.Templates, c); err != nil {
+			t.Fatalf("Scaffold(%s): %v", base, err)
+		}
+		cb, err := os.ReadFile(filepath.Join(dir, "eslint.config.mjs"))
+		if err != nil {
+			t.Fatalf("read eslint config for %s: %v", base, err)
+		}
+		pb, err := os.ReadFile(filepath.Join(dir, "package.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(cb), string(pb)
+	}
+
+	for _, base := range []BaseFramework{"astro-react", "vite-react"} {
+		conf, pkgJSON := scaffoldEslint(base)
+		for _, want := range []string{"eslint-plugin-react-hooks", "eslint-plugin-react-refresh"} {
+			if !strings.Contains(conf, want) {
+				t.Errorf("%s: eslint.config.mjs missing %s", base, want)
+			}
+			if !strings.Contains(pkgJSON, want) {
+				t.Errorf("%s: package.json missing %s", base, want)
+			}
+		}
+	}
+	for _, base := range []BaseFramework{"astro", "astro-vue", "vite-vue", "nuxt"} {
+		conf, pkgJSON := scaffoldEslint(base)
+		if strings.Contains(conf, "eslint-plugin-react") || strings.Contains(pkgJSON, "eslint-plugin-react") {
+			t.Errorf("%s: react eslint plugins leaked into a non-react base", base)
+		}
+	}
+}

--- a/pkg/configimports_test.go
+++ b/pkg/configimports_test.go
@@ -1,0 +1,106 @@
+package pkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spencer-osbrjp/bungkus-cli/config"
+)
+
+var importSpecRE = regexp.MustCompile(`(?m)^\s*import\s+(?:[^'"]*?\sfrom\s+)?['"]([^'"]+)['"]`)
+
+// packageName extracts the npm package a specifier resolves to
+// ("eslint/config" -> "eslint", "@eslint/js" -> "@eslint/js").
+func packageName(spec string) string {
+	parts := strings.Split(spec, "/")
+	if strings.HasPrefix(spec, "@") && len(parts) >= 2 {
+		return parts[0] + "/" + parts[1]
+	}
+	return parts[0]
+}
+
+// TestGeneratedConfigImportsAreInstalled guards the issue #118 class of bug:
+// every package imported by a generated top-level config file (eslint.config,
+// vite.config, astro.config, ...) must actually be installed by the generated
+// package.json. A config template importing a tool the registry entry does
+// not ship breaks the project's very first lint/build.
+func TestGeneratedConfigImportsAreInstalled(t *testing.T) {
+	setupRegistry(t)
+
+	combo := func(base BaseFramework, mutate func(*ProjectConfig)) ProjectConfig {
+		c := NewProjectConfig()
+		c.Base = base
+		if mutate != nil {
+			mutate(&c)
+		}
+		return c
+	}
+	eslint := func(c *ProjectConfig) { c.Fmt, c.Linter, c.CSS = "prettier", "eslint", "tailwindcss" }
+
+	combos := map[string]ProjectConfig{
+		"astro_eslint":       combo("astro", eslint), // the issue #118 repro
+		"astro_react_eslint": combo("astro-react", eslint),
+		"astro_vue_eslint":   combo("astro-vue", eslint),
+		"vite_vue_eslint":    combo("vite-vue", eslint),
+		"vite_react_eslint":  combo("vite-react", eslint),
+		"nuxt_eslint":        combo("nuxt", eslint),
+		"vite_ox":            combo("vite", func(c *ProjectConfig) { c.Fmt, c.Linter = "oxfmt", "oxlint" }),
+		"astro_defaults":     combo("astro", nil),
+		"vite_playwright":    combo("vite-react", func(c *ProjectConfig) { c.Test = "playwright" }),
+	}
+
+	for name, cfg := range combos {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := Scaffold(dir, config.Templates, cfg); err != nil {
+				t.Fatalf("Scaffold: %v", err)
+			}
+
+			raw, err := os.ReadFile(filepath.Join(dir, "package.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var pj struct {
+				Dependencies    map[string]string `json:"dependencies"`
+				DevDependencies map[string]string `json:"devDependencies"`
+			}
+			if err := json.Unmarshal(raw, &pj); err != nil {
+				t.Fatal(err)
+			}
+			installed := func(name string) bool {
+				_, d := pj.Dependencies[name]
+				_, dd := pj.DevDependencies[name]
+				return d || dd
+			}
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, e := range entries {
+				n := e.Name()
+				if e.IsDir() || !strings.Contains(n, ".config.") {
+					continue
+				}
+				b, err := os.ReadFile(filepath.Join(dir, n))
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, m := range importSpecRE.FindAllStringSubmatch(string(b), -1) {
+					spec := m[1]
+					if strings.HasPrefix(spec, ".") || strings.HasPrefix(spec, "/") ||
+						strings.HasPrefix(spec, "node:") || strings.Contains(spec, ":") {
+						continue // relative, absolute, builtin, or virtual module
+					}
+					if pkg := packageName(spec); !installed(pkg) {
+						t.Errorf("%s imports %q but package.json does not install %q", n, spec, pkg)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/packagejson.go
+++ b/pkg/packagejson.go
@@ -336,12 +336,14 @@ func applyCrossCuttingRules(pkg *packageJSON, cfg ProjectConfig) {
 		pkg.DevDependencies["prettier-plugin-astro"] = "0.14.1"
 	}
 
-	// eslint + vite-react → extra React eslint plugins
-	if cfg.Linter == "eslint" && cfg.Base == "vite-react" {
-		pkg.DevDependencies["globals"] = "^17.4.0"
+	// eslint + a react-integrated base → react eslint plugins. The generated
+	// eslint.config.mjs imports these whenever the base has a react
+	// integration, so the deps must track the same condition (issue #118:
+	// globals/typescript-eslint are imported unconditionally and live in the
+	// registry's eslint entry instead).
+	if cfg.Linter == "eslint" && cfg.Base.IsReactInt() {
 		pkg.DevDependencies["eslint-plugin-react-hooks"] = "^7.0.1"
 		pkg.DevDependencies["eslint-plugin-react-refresh"] = "^0.5.2"
-		pkg.DevDependencies["typescript-eslint"] = "^8.58.0"
 	}
 
 	// veevalidate + zod → @vee-validate/zod adapter


### PR DESCRIPTION
Closes #118

## Root cause

`templates/linter/eslint/eslint.config.mjs.tmpl` imported `globals`, `typescript-eslint`, `eslint-plugin-react-hooks`, and `eslint-plugin-react-refresh` unconditionally, but the registry's eslint entry only ships `eslint` + `@eslint/js`, and the react-plugin dependency rule fired only for `vite-react`. Every other base (the reporter used plain Astro) hit `Cannot find package` on its first husky pre-push lint. The `**/*.{ts,tsx,vue,astro}` glob also fed `.astro`/`.vue` files to a config with no matching parser.

## Fix

- `globals` + `typescript-eslint` move into the registry's eslint entry — an unconditional import is an unconditional dependency.
- The react plugin imports are wrapped in the template's existing `IsReactInt` condition, and the dep rule now tracks the same condition (`vite-react` **and** `astro-react`, which was silently broken too).
- The lint glob narrows to `**/*.{ts,tsx}` — matching what the shipped config can actually parse.

Plain-Astro output now matches the issue's "working config" verbatim.

## Preventing the class

New `TestGeneratedConfigImportsAreInstalled`: scaffolds nine representative combos (every base × eslint, ox tooling, playwright, defaults) and asserts that **every package imported by a generated top-level config file is installed by the generated package.json**. Any future template/registry drift of this kind fails CI instead of the user's first push.

## Testing

`go test ./...` green (the new guard test fails on the pre-fix templates for astro/astro-vue/vite-vue/nuxt/astro-react). E2E: scaffolded `-t astro`, confirmed the rendered config and devDependencies line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)