### PR TITLE
ci(release): fail loudly when a squashed promotion strips main's history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # A squashed promotion collapses main's fix:/feat: commits into one
+      # chore: commit, so semantic-release silently cuts no stable release
+      # (this happened with PR #107). Fail loudly instead.
+      - name: "Guard: release must contain main's history"
+        if: github.ref == 'refs/heads/release'
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor origin/main HEAD || {
+            echo "::error::release does not contain main's commit history — was the promotion PR squashed? Merge it with a merge commit so semantic-release can read the fix:/feat: commits."
+            exit 1
+          }
+
       - uses: actions/setup-node@v7
         with:
           node-version: 22


### PR DESCRIPTION
Prevention follow-up to the #107 incident: the promotion PR was squash-merged, which collapsed all of main's `fix:`/`feat:` commits into one `chore:` commit — semantic-release found no relevant changes and silently skipped the stable release (Build/Attach/Announce all skipped). v1.5.0 had to be cut by re-promoting with a true merge.

This adds a guard to the `semantic-release` job, active only on the `release` branch: if `origin/main` is not an ancestor of `HEAD`, the run fails with an error naming the squash as the cause, instead of quietly releasing nothing.

Note: if main advances between promotion-merge and the guard running, the check can trip on a technically-correct promotion — that's deliberate erring on the loud side; re-promote to clear it.

Second half of the prevention (not in this PR, needs admin): a ruleset restricting PRs into `release` to merge commits only, so the wrong button doesn't exist. Command included in the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)